### PR TITLE
L2BC 3.70

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -3081,6 +3081,14 @@
         <cd:MatchData offset="95">L2B/L2C IODD Iss. 03.60</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
+    <cd:ProductDefinition id="ALD_U_N_2C_03_70" format="binary" version="10">
+      <cd:Description>This definition is based on version 3.70 of IODD AED-SD-ECMWF-L2B-037</cd:Description>
+      <cd:DetectionRule>
+        <cd:MatchData offset="0">PRODUCT="AE_</cd:MatchData>
+        <cd:MatchData offset="17">ALD_U_N_2C</cd:MatchData>
+        <cd:MatchData offset="95">L2B/L2C IODD Iss. 03.70</cd:MatchData>
+      </cd:DetectionRule>
+    </cd:ProductDefinition>
   </cd:ProductType>
   <cd:ProductType name="ALD_U_N_2C_HDR">
     <cd:Description>Aeolus Level 2C Product (HDR)</cd:Description>
@@ -3136,6 +3144,9 @@
       </cd:DetectionRule>
       <cd:DetectionRule>
         <cd:MatchData path="/{http://www.esa.int/schemas/ae/ALD_U_N_2C}Earth_Explorer_Header@schemaversion">03.60</cd:MatchData>
+      </cd:DetectionRule>
+      <cd:DetectionRule>
+        <cd:MatchData path="/{http://www.esa.int/schemas/ae/ALD_U_N_2C}Earth_Explorer_Header@schemaversion">03.70</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
   </cd:ProductType>

--- a/index.xml
+++ b/index.xml
@@ -2925,6 +2925,14 @@
         <cd:MatchData offset="95">L2B/L2C IODD Iss. 03.60</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
+    <cd:ProductDefinition id="ALD_U_N_2B_03_70" format="binary" version="10">
+      <cd:Description>This definition is based on version 3.70 of IODD AED-SD-ECMWF-L2B-037</cd:Description>
+      <cd:DetectionRule>
+        <cd:MatchData offset="0">PRODUCT="AE_</cd:MatchData>
+        <cd:MatchData offset="17">ALD_U_N_2B</cd:MatchData>
+        <cd:MatchData offset="95">L2B/L2C IODD Iss. 03.70</cd:MatchData>
+      </cd:DetectionRule>
+    </cd:ProductDefinition>
   </cd:ProductType>
   <cd:ProductType name="ALD_U_N_2B_HDR">
     <cd:Description>Aeolus Level 2B Product (HDR)</cd:Description>
@@ -2980,6 +2988,9 @@
       </cd:DetectionRule>
       <cd:DetectionRule>
         <cd:MatchData path="/{http://www.esa.int/schemas/ae/ALD_U_N_2B}Earth_Explorer_Header@schemaversion">03.60</cd:MatchData>
+      </cd:DetectionRule>
+      <cd:DetectionRule>
+        <cd:MatchData path="/{http://www.esa.int/schemas/ae/ALD_U_N_2B}Earth_Explorer_Header@schemaversion">03.70</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
   </cd:ProductType>

--- a/index.xml
+++ b/index.xml
@@ -3400,6 +3400,12 @@
         <cd:MatchData path="/{http://www.esa.int/schemas/ae/AUX_PAR_2B}Earth_Explorer_File@schemaversion">03.60</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
+    <cd:ProductDefinition id="AUX_PAR_2B_03_70" format="xml" version="11">
+      <cd:Description>This definition is based on version 3.70 of IODD AED-SD-ECMWF-L2B-037</cd:Description>
+      <cd:DetectionRule>
+        <cd:MatchData path="/{http://www.esa.int/schemas/ae/AUX_PAR_2B}Earth_Explorer_File@schemaversion">03.70</cd:MatchData>
+      </cd:DetectionRule>
+    </cd:ProductDefinition>
   </cd:ProductType>
   <cd:ProductType name="AUX_PAR_2C">
     <cd:Description>Level 2C Processing Parameters (EEF)</cd:Description>

--- a/index.xml
+++ b/index.xml
@@ -3325,6 +3325,12 @@
         <cd:MatchData path="/{http://www.esa.int/schemas/ae/AUX_TEL_12}Earth_Explorer_File@schemaversion">03.60</cd:MatchData>
       </cd:DetectionRule>
     </cd:ProductDefinition>
+    <cd:ProductDefinition id="AUX_TEL_12_03_70" format="xml" version="3">
+      <cd:Description>This definition is based on version 3.70 of IODD AED-SD-ECMWF-L2B-037</cd:Description>
+      <cd:DetectionRule>
+        <cd:MatchData path="/{http://www.esa.int/schemas/ae/AUX_TEL_12}Earth_Explorer_File@schemaversion">03.70</cd:MatchData>
+      </cd:DetectionRule>
+    </cd:ProductDefinition>
   </cd:ProductType>
   <cd:ProductType name="AUX_PAR_2B">
     <cd:Description>Level 2B Processing Parameters (EEF)</cd:Description>

--- a/products/ALD_U_N_2B_03_70.xml
+++ b/products/ALD_U_N_2B_03_70.xml
@@ -90,7 +90,7 @@
       <cd:Array>
         <cd:Description>Mie Wind Product Confidence Data</cd:Description>
         <cd:Dimension><![CDATA[$num_dsr[8]]]></cd:Dimension>
-        <cd:NamedType id="Level_2BC_Mie_Wind_PCD_ADSR_03_30"/>
+        <cd:NamedType id="Level_2BC_Mie_Wind_PCD_ADSR_03_70"/>
       </cd:Array>
       <cd:Available><![CDATA[$ds_available[8] != 0]]></cd:Available>
       <cd:BitOffset><![CDATA[$ds_offset[8]]]></cd:BitOffset>
@@ -99,7 +99,7 @@
       <cd:Array>
         <cd:Description>Rayleigh Wind Product Confidence Data</cd:Description>
         <cd:Dimension><![CDATA[$num_dsr[9]]]></cd:Dimension>
-        <cd:NamedType id="Level_2BC_Rayleigh_Wind_PCD_ADSR_03_30"/>
+        <cd:NamedType id="Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70"/>
       </cd:Array>
       <cd:Available><![CDATA[$ds_available[9] != 0]]></cd:Available>
       <cd:BitOffset><![CDATA[$ds_offset[9]]]></cd:BitOffset>

--- a/products/ALD_U_N_2B_03_70.xml
+++ b/products/ALD_U_N_2B_03_70.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0"?>
+<cd:ProductDefinition xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" id="ALD_U_N_2B_03_70" format="binary" last-modified="2022-01-19">
+  <cd:Record format="binary">
+    <cd:Description>Level 2B Product</cd:Description>
+    <cd:Field name="mph">
+      <cd:NamedType id="MPH_v3"/>
+    </cd:Field>
+    <cd:Field name="sph">
+      <cd:NamedType id="Level_2B_SPH_03_30"/>
+    </cd:Field>
+    <cd:Field name="dsd">
+      <cd:Array format="ascii">
+        <cd:Dimension><![CDATA[$num_dsd]]></cd:Dimension>
+        <cd:NamedType id="DSD"/>
+      </cd:Array>
+    </cd:Field>
+    <cd:Field name="meas_map">
+      <cd:Array>
+        <cd:Description>Measurement Map Annotation</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[0]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Meas_Map_ADSR"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[0] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[0]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_grouping">
+      <cd:Array>
+        <cd:Description>Mie Grouping ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[1]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Grouping_ADSR_02_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[1] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[1]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_grouping">
+      <cd:Array>
+        <cd:Description>Rayleigh Grouping ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[2]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Grouping_ADSR_02_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[2] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[2]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="copied_brc_data">
+      <cd:Array>
+        <cd:Description>Copied BRC Data ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[3]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Copied_BRC_Data_ADSR"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[3] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[3]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_geolocation">
+      <cd:Array>
+        <cd:Description>Mie Wind Geolocation Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[4]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Geolocation_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[4] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[4]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_geolocation">
+      <cd:Array>
+        <cd:Description>Rayleigh Wind Geolocation Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[5]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Geolocation_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[5] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[5]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="amd_product_confid_data">
+      <cd:Array>
+        <cd:Description>AMD Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[6]]]></cd:Dimension>
+        <cd:NamedType id="Level_2B_AMD_PCD_ADSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[6] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[6]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="meas_product_confid_data">
+      <cd:Array>
+        <cd:Description>Measurement level Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[7]]]></cd:Dimension>
+        <cd:NamedType id="Level_2B_Meas_PCD_ADSR_03_60"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[7] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[7]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_wind_prod_conf_data">
+      <cd:Array>
+        <cd:Description>Mie Wind Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[8]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Mie_Wind_PCD_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[8] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[8]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_wind_prod_conf_data">
+      <cd:Array>
+        <cd:Description>Rayleigh Wind Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[9]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Rayleigh_Wind_PCD_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[9] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[9]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_hloswind">
+      <cd:Array>
+        <cd:Description>Mie HLOS winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[10]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Mie_HLOSWind_MDSR_03_60"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[10] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[10]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfMieWindVelocityMissing"/>
+    </cd:Field>
+    <cd:Field name="rayleigh_hloswind">
+      <cd:Array>
+        <cd:Description>Rayleigh HLOS winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[11]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Rayleigh_HLOSWind_MDSR_03_60"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[11] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[11]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfRayleighWindVelocityMissing"/>
+    </cd:Field>
+    <cd:Field name="mie_profile">
+      <cd:Array>
+        <cd:Description>Mie Profile</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[12]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Wind_Profile_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[12] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[12]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_profile">
+      <cd:Array>
+        <cd:Description>Rayleigh Profile</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[13]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Wind_Profile_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[13] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[13]]]></cd:BitOffset>
+    </cd:Field>
+  </cd:Record>
+  <cd:ProductVariable name="num_dsd">
+    <cd:Init><![CDATA[$num_dsd = int(/mph/num_dsd)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="num_ds">
+    <cd:Init><![CDATA[$num_ds = 14]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_to_dsd_index">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[$ds_to_dsd_index[0] = index(/dsd, str(./ds_name) == "Meas_Map_ADS                "); $ds_to_dsd_index[1] = index(/dsd, str(./ds_name) == "Mie_Grouping_ADS            "); $ds_to_dsd_index[2] = index(/dsd, str(./ds_name) == "Rayleigh_Grouping_ADS       "); $ds_to_dsd_index[3] = index(/dsd, str(./ds_name) == "Copied_BRC_Data_ADS         "); $ds_to_dsd_index[4] = index(/dsd, str(./ds_name) == "Mie_Geolocation_ADS         "); $ds_to_dsd_index[5] = index(/dsd, str(./ds_name) == "Rayleigh_Geolocation_ADS    "); $ds_to_dsd_index[6] = index(/dsd, str(./ds_name) == "AMD_Product_Confid_Data_ADS "); $ds_to_dsd_index[7] = index(/dsd, str(./ds_name) == "Meas_Product_Confid_Data_ADS"); $ds_to_dsd_index[8] = index(/dsd, str(./ds_name) == "Mie_Wind_Prod_Conf_Data_ADS "); $ds_to_dsd_index[9] = index(/dsd, str(./ds_name) == "Rayl_Wind_Prod_Conf_Data_ADS"); $ds_to_dsd_index[10] = index(/dsd, str(./ds_name) == "Mie_Wind_MDS                "); $ds_to_dsd_index[11] = index(/dsd, str(./ds_name) == "Rayleigh_Wind_MDS           "); $ds_to_dsd_index[12] = index(/dsd, str(./ds_name) == "Mie_Profile_MDS             "); $ds_to_dsd_index[13] = index(/dsd, str(./ds_name) == "Rayleigh_Profile_MDS        ")]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_available">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $ds_available[i] = if($ds_to_dsd_index[i] != -1 && int(/dsd[$ds_to_dsd_index[i]]/ds_size) != 0, 1, 0)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_offset">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $ds_offset[i] = 8 * int(/dsd[$ds_to_dsd_index[i]]/ds_offset)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="num_dsr">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $num_dsr[i] = int(/dsd[$ds_to_dsd_index[i]]/num_dsr)]]></cd:Init>
+  </cd:ProductVariable>
+  <!-- MPH Cross File Tests -->
+  <ct:NamedCrossFileTest id="MPH_Product"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Stage"/>
+  <ct:NamedCrossFileTest id="MPH_Ref_Doc"/>
+  <ct:NamedCrossFileTest id="MPH_Acquisition_Station"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Center"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Software_Ver"/>
+  <ct:NamedCrossFileTest id="MPH_Baseline"/>
+  <ct:NamedCrossFileTest id="MPH_Sensing_Start"/>
+  <ct:NamedCrossFileTest id="MPH_Sensing_Stop"/>
+  <ct:NamedCrossFileTest id="MPH_Phase"/>
+  <ct:NamedCrossFileTest id="MPH_Cycle"/>
+  <ct:NamedCrossFileTest id="MPH_Rel_Orbit"/>
+  <ct:NamedCrossFileTest id="MPH_Abs_Orbit"/>
+  <ct:NamedCrossFileTest id="MPH_State_Vector_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Delta_UT1"/>
+  <ct:NamedCrossFileTest id="MPH_X_Position"/>
+  <ct:NamedCrossFileTest id="MPH_Y_Position"/>
+  <ct:NamedCrossFileTest id="MPH_Z_Position"/>
+  <ct:NamedCrossFileTest id="MPH_X_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Y_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Z_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Vector_Source"/>
+  <ct:NamedCrossFileTest id="MPH_Utc_Sbt_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Sat_Binary_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Utc"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Sign"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Err"/>
+  <ct:NamedCrossFileTest id="MPH_Product_Err"/>
+  <ct:NamedCrossFileTest id="MPH_Tot_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Sph_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Num_Dsd"/>
+  <ct:NamedCrossFileTest id="MPH_Dsd_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Num_Data_Sets"/>
+  <!-- SPH Cross File Tests -->
+  <ct:NamedCrossFileTest id="SPH_Sph_Descriptor"/>
+  <ct:NamedCrossFileTest id="SPH_NumMeasurements"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieGroups"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighGroups"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieWindResults"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighWindResults"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieProfiles"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighProfiles"/>
+  <ct:NamedCrossFileTest id="SPH_NumAMDprofiles"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_start_lat"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_start_long"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_stop_lat"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_stop_long"/>
+  <ct:NamedCrossFileTest id="SPH_Sat_Track"/>
+  <ct:NamedCrossFileTest id="SPH_Num_Profiles_Surface_Mie"/>
+  <ct:NamedCrossFileTest id="SPH_Num_Profiles_Surface_Ray"/>
+</cd:ProductDefinition>

--- a/products/ALD_U_N_2B_03_70.xml
+++ b/products/ALD_U_N_2B_03_70.xml
@@ -18,7 +18,7 @@
       <cd:Array>
         <cd:Description>Measurement Map Annotation</cd:Description>
         <cd:Dimension><![CDATA[$num_dsr[0]]]></cd:Dimension>
-        <cd:NamedType id="Level_2BC_Meas_Map_ADSR"/>
+        <cd:NamedType id="Level_2BC_Meas_Map_ADSR_03_70"/>
       </cd:Array>
       <cd:Available><![CDATA[$ds_available[0] != 0]]></cd:Available>
       <cd:BitOffset><![CDATA[$ds_offset[0]]]></cd:BitOffset>

--- a/products/ALD_U_N_2B_03_70.xml
+++ b/products/ALD_U_N_2B_03_70.xml
@@ -81,7 +81,7 @@
       <cd:Array>
         <cd:Description>Measurement level Product Confidence Data</cd:Description>
         <cd:Dimension><![CDATA[$num_dsr[7]]]></cd:Dimension>
-        <cd:NamedType id="Level_2B_Meas_PCD_ADSR_03_60"/>
+        <cd:NamedType id="Level_2B_Meas_PCD_ADSR_03_70"/>
       </cd:Array>
       <cd:Available><![CDATA[$ds_available[7] != 0]]></cd:Available>
       <cd:BitOffset><![CDATA[$ds_offset[7]]]></cd:BitOffset>

--- a/products/ALD_U_N_2C_03_70.xml
+++ b/products/ALD_U_N_2C_03_70.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0"?>
+<cd:ProductDefinition xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" id="ALD_U_N_2C_03_70" format="binary" last-modified="2022-01-19">
+  <cd:Record format="binary">
+    <cd:Description>Level 2C Product</cd:Description>
+    <cd:Field name="mph">
+      <cd:NamedType id="MPH_v3"/>
+    </cd:Field>
+    <cd:Field name="sph">
+      <cd:NamedType id="Level_2C_SPH_03_30"/>
+    </cd:Field>
+    <cd:Field name="dsd">
+      <cd:Array format="ascii">
+        <cd:Dimension><![CDATA[$num_dsd]]></cd:Dimension>
+        <cd:NamedType id="DSD"/>
+      </cd:Array>
+    </cd:Field>
+    <cd:Field name="meas_map">
+      <cd:Array>
+        <cd:Description>Measurement Map Annotation</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[0]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Meas_Map_ADSR_03_70"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[0] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[0]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_grouping">
+      <cd:Array>
+        <cd:Description>Mie Grouping ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[1]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Grouping_ADSR_02_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[1] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[1]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_grouping">
+      <cd:Array>
+        <cd:Description>Rayleigh Grouping ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[2]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Grouping_ADSR_02_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[2] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[2]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="copied_brc_data">
+      <cd:Array>
+        <cd:Description>Copied BRC Data ADS</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[3]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Copied_BRC_Data_ADSR"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[3] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[3]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_geolocation">
+      <cd:Array>
+        <cd:Description>Mie Wind Geolocation Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[4]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Geolocation_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[4] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[4]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_geolocation">
+      <cd:Array>
+        <cd:Description>Rayleigh Wind Geolocation Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[5]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Geolocation_ADSR_03_30"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[5] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[5]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="amd_product_confid_data">
+      <cd:Array>
+        <cd:Description>AMD Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[6]]]></cd:Dimension>
+        <cd:NamedType id="Level_2B_AMD_PCD_ADSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[6] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[6]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="meas_product_confid_data">
+      <cd:Array>
+        <cd:Description>Measurement level Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[7]]]></cd:Dimension>
+        <cd:NamedType id="Level_2B_Meas_PCD_ADSR_03_70"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[7] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[7]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_wind_prod_conf_data">
+      <cd:Array>
+        <cd:Description>Mie Wind Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[8]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Mie_Wind_PCD_ADSR_03_70"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[8] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[8]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_wind_prod_conf_data">
+      <cd:Array>
+        <cd:Description>Rayleigh Wind Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[9]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[9] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[9]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_hloswind">
+      <cd:Array>
+        <cd:Description>Mie HLOS winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[10]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Mie_HLOSWind_MDSR_03_60"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[10] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[10]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfMieWindVelocityMissing"/>
+    </cd:Field>
+    <cd:Field name="rayleigh_hloswind">
+      <cd:Array>
+        <cd:Description>Rayleigh HLOS winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[11]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Rayleigh_HLOSWind_MDSR_03_60"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[11] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[11]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfRayleighWindVelocityMissing"/>
+    </cd:Field>
+    <cd:Field name="mie_profile">
+      <cd:Array>
+        <cd:Description>Mie Profile</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[12]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Wind_Profile_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[12] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[12]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_profile">
+      <cd:Array>
+        <cd:Description>Rayleigh Profile</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[13]]]></cd:Dimension>
+        <cd:NamedType id="Level_2BC_Wind_Profile_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[13] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[13]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_assim_pcd">
+      <cd:Array>
+        <cd:Description>Mie assimilation Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[14]]]></cd:Dimension>
+        <cd:NamedType id="Level_2C_Mie_Assim_PCD_ADSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[14] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[14]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="rayleigh_assim_pcd">
+      <cd:Array>
+        <cd:Description>Rayleigh assimilation Product Confidence Data</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[15]]]></cd:Dimension>
+        <cd:NamedType id="Level_2C_Rayleigh_Assim_PCD_ADSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[15] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[15]]]></cd:BitOffset>
+    </cd:Field>
+    <cd:Field name="mie_vecwind">
+      <cd:Array>
+        <cd:Description>Mie vector winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[16]]]></cd:Dimension>
+        <cd:NamedType id="Level_2C_Mie_VecWind_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[16] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[16]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfBackgroundZonalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfBackgroundMeridionalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfAnalysisZonalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfAnalysisMeridionalWindVelocityMissing"/>
+    </cd:Field>
+    <cd:Field name="rayleigh_vecwind">
+      <cd:Array>
+        <cd:Description>Rayleigh vector winds</cd:Description>
+        <cd:Dimension><![CDATA[$num_dsr[17]]]></cd:Dimension>
+        <cd:NamedType id="Level_2C_Rayleigh_VecWind_MDSR_02_00"/>
+      </cd:Array>
+      <cd:Available><![CDATA[$ds_available[17] != 0]]></cd:Available>
+      <cd:BitOffset><![CDATA[$ds_offset[17]]]></cd:BitOffset>
+      <ct:NamedTest id="LessThanOnePercentOfBackgroundZonalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfBackgroundMeridionalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfAnalysisZonalWindVelocityMissing"/>
+      <ct:NamedTest id="LessThanOnePercentOfAnalysisMeridionalWindVelocityMissing"/>
+    </cd:Field>
+  </cd:Record>
+  <cd:ProductVariable name="num_dsd">
+    <cd:Init><![CDATA[$num_dsd = int(/mph/num_dsd)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="num_ds">
+    <cd:Init><![CDATA[$num_ds = 18]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_to_dsd_index">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[$ds_to_dsd_index[0] = index(/dsd, str(./ds_name) == "Meas_Map_ADS                "); $ds_to_dsd_index[1] = index(/dsd, str(./ds_name) == "Mie_Grouping_ADS            "); $ds_to_dsd_index[2] = index(/dsd, str(./ds_name) == "Rayleigh_Grouping_ADS       "); $ds_to_dsd_index[3] = index(/dsd, str(./ds_name) == "Copied_BRC_Data_ADS         "); $ds_to_dsd_index[4] = index(/dsd, str(./ds_name) == "Mie_Geolocation_ADS         "); $ds_to_dsd_index[5] = index(/dsd, str(./ds_name) == "Rayleigh_Geolocation_ADS    "); $ds_to_dsd_index[6] = index(/dsd, str(./ds_name) == "AMD_Product_Confid_Data_ADS "); $ds_to_dsd_index[7] = index(/dsd, str(./ds_name) == "Meas_Product_Confid_Data_ADS"); $ds_to_dsd_index[8] = index(/dsd, str(./ds_name) == "Mie_Wind_Prod_Conf_Data_ADS "); $ds_to_dsd_index[9] = index(/dsd, str(./ds_name) == "Rayl_Wind_Prod_Conf_Data_ADS"); $ds_to_dsd_index[10] = index(/dsd, str(./ds_name) == "Mie_Wind_MDS                "); $ds_to_dsd_index[11] = index(/dsd, str(./ds_name) == "Rayleigh_Wind_MDS           "); $ds_to_dsd_index[12] = index(/dsd, str(./ds_name) == "Mie_Profile_MDS             "); $ds_to_dsd_index[13] = index(/dsd, str(./ds_name) == "Rayleigh_Profile_MDS        "); $ds_to_dsd_index[14] = index(/dsd, str(./ds_name) == "Mie_Assim_PCD_ADS           "); $ds_to_dsd_index[15] = index(/dsd, str(./ds_name) == "Rayl_Assim_PCD_ADS          "); $ds_to_dsd_index[16] = index(/dsd, str(./ds_name) == "Mie_VecWind_MDS             "); $ds_to_dsd_index[17] = index(/dsd, str(./ds_name) == "Rayleigh_VecWind_MDS        ")]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_available">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $ds_available[i] = if($ds_to_dsd_index[i] != -1 && int(/dsd[$ds_to_dsd_index[i]]/ds_size) != 0, 1, 0)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="ds_offset">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $ds_offset[i] = 8 * int(/dsd[$ds_to_dsd_index[i]]/ds_offset)]]></cd:Init>
+  </cd:ProductVariable>
+  <cd:ProductVariable name="num_dsr">
+    <cd:Dimension><![CDATA[$num_ds]]></cd:Dimension>
+    <cd:Init><![CDATA[for i = 0 to $num_ds - 1 do $num_dsr[i] = int(/dsd[$ds_to_dsd_index[i]]/num_dsr)]]></cd:Init>
+  </cd:ProductVariable>
+  <!-- MPH Cross File Tests -->
+  <ct:NamedCrossFileTest id="MPH_Product"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Stage"/>
+  <ct:NamedCrossFileTest id="MPH_Ref_Doc"/>
+  <ct:NamedCrossFileTest id="MPH_Acquisition_Station"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Center"/>
+  <ct:NamedCrossFileTest id="MPH_Proc_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Software_Ver"/>
+  <ct:NamedCrossFileTest id="MPH_Baseline"/>
+  <ct:NamedCrossFileTest id="MPH_Sensing_Start"/>
+  <ct:NamedCrossFileTest id="MPH_Sensing_Stop"/>
+  <ct:NamedCrossFileTest id="MPH_Phase"/>
+  <ct:NamedCrossFileTest id="MPH_Cycle"/>
+  <ct:NamedCrossFileTest id="MPH_Rel_Orbit"/>
+  <ct:NamedCrossFileTest id="MPH_Abs_Orbit"/>
+  <ct:NamedCrossFileTest id="MPH_State_Vector_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Delta_UT1"/>
+  <ct:NamedCrossFileTest id="MPH_X_Position"/>
+  <ct:NamedCrossFileTest id="MPH_Y_Position"/>
+  <ct:NamedCrossFileTest id="MPH_Z_Position"/>
+  <ct:NamedCrossFileTest id="MPH_X_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Y_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Z_Velocity"/>
+  <ct:NamedCrossFileTest id="MPH_Vector_Source"/>
+  <ct:NamedCrossFileTest id="MPH_Utc_Sbt_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Sat_Binary_Time"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Utc"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Sign"/>
+  <ct:NamedCrossFileTest id="MPH_Leap_Err"/>
+  <ct:NamedCrossFileTest id="MPH_Product_Err"/>
+  <ct:NamedCrossFileTest id="MPH_Tot_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Sph_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Num_Dsd"/>
+  <ct:NamedCrossFileTest id="MPH_Dsd_Size"/>
+  <ct:NamedCrossFileTest id="MPH_Num_Data_Sets"/>
+  <!-- SPH Cross File Tests -->
+  <ct:NamedCrossFileTest id="SPH_Sph_Descriptor"/>
+  <ct:NamedCrossFileTest id="SPH_NumMeasurements"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieGroups"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighGroups"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieWindResults"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighWindResults"/>
+  <ct:NamedCrossFileTest id="SPH_NumMieProfiles"/>
+  <ct:NamedCrossFileTest id="SPH_NumRayleighProfiles"/>
+  <ct:NamedCrossFileTest id="SPH_NumAMDprofiles"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_start_lat"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_start_long"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_stop_lat"/>
+  <ct:NamedCrossFileTest id="SPH_intersect_stop_long"/>
+  <ct:NamedCrossFileTest id="SPH_Sat_Track"/>
+  <ct:NamedCrossFileTest id="SPH_Num_Profiles_Surface_Mie"/>
+  <ct:NamedCrossFileTest id="SPH_Num_Profiles_Surface_Ray"/>
+</cd:ProductDefinition>

--- a/products/AUX_PAR_2B_03_70.xml
+++ b/products/AUX_PAR_2B_03_70.xml
@@ -32,7 +32,7 @@
               <cd:FixedValue>xml</cd:FixedValue>
             </cd:Attribute>
             <cd:Field name="Level_2B_Proc_Params">
-              <cd:NamedType id="Level_2B_Proc_Params_03_60"/>
+              <cd:NamedType id="Level_2B_Proc_Params_03_70"/>
             </cd:Field>
           </cd:Record>
         </cd:Field>

--- a/products/AUX_PAR_2B_03_70.xml
+++ b/products/AUX_PAR_2B_03_70.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<cd:ProductDefinition xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" id="AUX_PAR_2B_03_70" format="xml" last-modified="2022-01-19">
+  <cd:Record format="xml">
+    <cd:Field name="Earth_Explorer_File">
+      <cd:Record namexml="Earth_Explorer_File">
+        <cd:Attribute name="schemaversion"/>
+        <cd:Description>Earth Explorer File</cd:Description>
+        <cd:Field name="Earth_Explorer_Header">
+          <cd:Record namexml="Earth_Explorer_Header">
+            <cd:Description>Earth Explorer Header File</cd:Description>
+            <cd:Field name="Fixed_Header">
+              <cd:NamedType id="Fixed_Header"/>
+            </cd:Field>
+            <cd:Field name="Variable_Header">
+              <cd:Record namexml="Variable_Header">
+                <cd:Description>Variable Header Section</cd:Description>
+                <cd:Field name="Main_Product_Header">
+                  <cd:NamedType id="Main_Product_Header_v3"/>
+                </cd:Field>
+                <cd:Field name="Specific_Product_Header">
+                  <cd:NamedType id="Specific_Product_Header_Par2B_01_40"/>
+                </cd:Field>
+              </cd:Record>
+            </cd:Field>
+            <ct:NamedTest id="FileNameMatchValidityStart" path="Fixed_Header/File_Name"/>
+          </cd:Record>
+        </cd:Field>
+        <cd:Field name="Data_Block">
+          <cd:Record namexml="Data_Block">
+            <cd:Attribute name="type">
+              <cd:Optional/>
+              <cd:FixedValue>xml</cd:FixedValue>
+            </cd:Attribute>
+            <cd:Field name="Level_2B_Proc_Params">
+              <cd:NamedType id="Level_2B_Proc_Params_03_60"/>
+            </cd:Field>
+          </cd:Record>
+        </cd:Field>
+      </cd:Record>
+    </cd:Field>
+  </cd:Record>
+</cd:ProductDefinition>

--- a/products/AUX_TEL_12_03_70.xml
+++ b/products/AUX_TEL_12_03_70.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0"?>
+<cd:ProductDefinition xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" id="AUX_TEL_12_03_70" format="xml" last-modified="2022-01-19">
+  <cd:Record format="xml">
+    <cd:Field name="Earth_Explorer_File">
+      <cd:Record namexml="Earth_Explorer_File">
+        <cd:Attribute name="schemaversion"/>
+        <cd:Description>Earth Explorer File</cd:Description>
+        <cd:Field name="Earth_Explorer_Header">
+          <cd:Record namexml="Earth_Explorer_Header">
+            <cd:Description>Earth Explorer Header File</cd:Description>
+            <cd:Field name="Fixed_Header">
+              <cd:NamedType id="Fixed_Header"/>
+            </cd:Field>
+            <cd:Field name="Variable_Header">
+              <cd:Record namexml="Variable_Header">
+                <cd:Description>Variable Header Section</cd:Description>
+                <cd:Field name="Main_Product_Header">
+                  <cd:NamedType id="Main_Product_Header_v3"/>
+                </cd:Field>
+                <cd:Field name="Specific_Product_Header">
+                  <cd:Record>
+                    <cd:Field name="Sph_Descriptor">
+                      <cd:Text namexml="Sph_Descriptor">
+                        <cd:Description>ASCII string describing this collection of settings</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Fitting_Input_Data">
+                      <cd:Text namexml="Fitting_Input_Data">
+                        <cd:Description>ASCII string describing which data was used as input for the fitting procedure. Allowed values are "O_min_B" and "ZWC"</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Fitting_Algorithm_Used">
+                      <cd:Text namexml="Fitting_Algorithm_Used">
+                        <cd:Description>ASCII string describing which fitting algorithm was used for the fitting procedure. Allowed values are "CHAOS" and "MACH"</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Correct_HLOS_or_LOS_Bias">
+                      <cd:Text namexml="Correct_HLOS_or_LOS_Bias">
+                        <cd:Description>ASCII string describing along which axis the bias correction should be applied. Allowed values are "LOS" and "HLOS"</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Start_of_Fitting_Period">
+                      <cd:Type namexml="Start_of_Fitting_Period">
+                        <cd:Time format="ascii" timeformat="ascii_ccsds_datetime_ymd2_with_ref">
+                          <cd:Description>CoG datetime of the first wind result included in the fit.</cd:Description>
+                          <cd:Mapping string="UTC=0000-00-00T00:00:00" value="-inf"/>
+                          <cd:Mapping string="UTC=9999-99-99T99:99:99" value="+inf"/>
+                        </cd:Time>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Stop_of_Fitting_Period">
+                      <cd:Type namexml="Stop_of_Fitting_Period">
+                        <cd:Time format="ascii" timeformat="ascii_ccsds_datetime_ymd2_with_ref">
+                          <cd:Description>CoG datetime of the last wind result included in the fit.</cd:Description>
+                          <cd:Mapping string="UTC=0000-00-00T00:00:00" value="-inf"/>
+                          <cd:Mapping string="UTC=9999-99-99T99:99:99" value="+inf"/>
+                        </cd:Time>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Additional_Configuration_Settings">
+                      <cd:Text namexml="Additional_Configuration_Settings">
+                        <cd:Description>ASCII string holding free formatted multi-line text (to a maximum of 512 characters).</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Mie_Quality_Indicators">
+                      <cd:Text namexml="Mie_Quality_Indicators">
+                        <cd:Description>ASCII string holding free formatted multi-line text (to a maximum of 512 characters). This field typically lists R2, RMSE, data count and time range of the input data for the fit.</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Rayleigh_Quality_Indicators">
+                      <cd:Text namexml="Rayleigh_Quality_Indicators">
+                        <cd:Description>ASCII string holding free formatted multi-line text (to a maximum of 512 characters). This field typically lists R2, RMSE, data count and time range of the input data for the fit.</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                    <cd:Field name="Mie_Fit_Validity">
+                      <cd:Type namexml="Mie_Fit_Validity">
+                        <cd:Integer format="ascii">
+                          <cd:Description>Indicates if the fit was successful for the Mie winds. If it was not successful the fit results are unreliable (or missing) and should not be used for bias correcting the wind</cd:Description>
+                          <cd:NativeType>uint8</cd:NativeType>
+                          <cd:Mapping string="FALSE" value="0"/>
+                          <cd:Mapping string="False" value="0"/>
+                          <cd:Mapping string="false" value="0"/>
+                          <cd:Mapping string="TRUE" value="1"/>
+                          <cd:Mapping string="True" value="1"/>
+                          <cd:Mapping string="true" value="1"/>
+                        </cd:Integer>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Rayleigh_Fit_Validity">
+                      <cd:Type namexml="Rayleigh_Fit_Validity">
+                        <cd:Integer format="ascii">
+                          <cd:Description>Indicates if the fit was successful for the Rayleigh winds. If it was not successful the fit results are unreliable (or missing) and should not be used for bias correcting the wind</cd:Description>
+                          <cd:NativeType>uint8</cd:NativeType>
+                          <cd:Mapping string="FALSE" value="0"/>
+                          <cd:Mapping string="False" value="0"/>
+                          <cd:Mapping string="false" value="0"/>
+                          <cd:Mapping string="TRUE" value="1"/>
+                          <cd:Mapping string="True" value="1"/>
+                          <cd:Mapping string="true" value="1"/>
+                        </cd:Integer>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="List_of_Dsds">
+                      <cd:NamedType id="List_of_Dsds"/>
+                    </cd:Field>
+                  </cd:Record>
+                </cd:Field>
+              </cd:Record>
+            </cd:Field>
+            <ct:NamedTest id="FileNameMatchValidityStart" path="Fixed_Header/File_Name"/>
+          </cd:Record>
+        </cd:Field>
+        <cd:Field name="Data_Block">
+          <cd:Record namexml="Data_Block">
+            <cd:Attribute name="type">
+              <cd:Optional/>
+              <cd:FixedValue>xml</cd:FixedValue>
+            </cd:Attribute>
+            <cd:Field name="Tel_Corr_Params">
+              <cd:Record>
+                <cd:Field name="Mie_Channel_Correction_Factors">
+                  <cd:Record>
+                    <cd:Field name="M1_Telescope_Temperature_Correction_Factors">
+                        <cd:NamedType id="M1_Telescope_Temperature_Correction_Factors_03_70"/>
+                    </cd:Field>
+                    <cd:Field name="List_of_Orbit_Phase_Correction_Factors">
+                        <cd:NamedType id="List_of_Orbit_Phase_Correction_Factors"/>
+                    </cd:Field>
+                  </cd:Record>
+                </cd:Field>
+                <cd:Field name="Rayleigh_Channel_Correction_Factors">
+                  <cd:Record>
+                    <cd:Field name="M1_Telescope_Temperature_Correction_Factors">
+                        <cd:NamedType id="M1_Telescope_Temperature_Correction_Factors_03_70"/>
+                    </cd:Field>
+                    <cd:Field name="List_of_Orbit_Phase_Correction_Factors">
+                        <cd:NamedType id="List_of_Orbit_Phase_Correction_Factors"/>
+                    </cd:Field>
+                  </cd:Record>
+                </cd:Field>
+              </cd:Record>
+            </cd:Field>
+          </cd:Record>
+        </cd:Field>
+      </cd:Record>
+    </cd:Field>
+  </cd:Record>
+</cd:ProductDefinition>

--- a/types/Level_2BC_Meas_Map_ADSR_03_70.xml
+++ b/types/Level_2BC_Meas_Map_ADSR_03_70.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" format="binary" last-modified="2022-01-19" name="Level_2BC_Meas_Map_ADSR_03_70">
+  <cd:Field name="start_of_obs_datetime">
+    <cd:Time timeformat="binary_envisat_datetime">
+      <cd:Description>Start date and time of Measurement</cd:Description>
+      <ct:NamedTest id="RangeSecond" path="seconds"/>
+      <ct:NamedTest id="RangeMicroSecond" path="microseconds"/>
+    </cd:Time>
+  </cd:Field>
+  <cd:Field name="mie_map_of_l1b_meas_used">
+    <cd:Array>
+      <cd:Description>Map of Mie Measurements used by the L2B accumulations</cd:Description>
+      <cd:Dimension>24</cd:Dimension>
+      <cd:Record>
+        <cd:Field name="which_l2b_wind_id">
+          <cd:Integer>
+            <cd:Description>reference to the L2B wind result to which this L1B range bin contributed. It will be set to 0 if not used.</cd:Description>
+            <cd:BitSize>32</cd:BitSize>
+            <cd:NativeType>uint32</cd:NativeType>
+          </cd:Integer>
+        </cd:Field>
+        <cd:Field name="weight">
+          <cd:Integer>
+            <cd:Description>Weight used for this L1B range bin while accumulating the signals used to produce the L2B wind result to which this L1B range bin contributed. The valid range is 0-1000</cd:Description>
+            <cd:BitSize>16</cd:BitSize>
+            <cd:NativeType>uint16</cd:NativeType>
+          </cd:Integer>
+        </cd:Field>
+      </cd:Record>
+    </cd:Array>
+  </cd:Field>
+  <cd:Field name="mie_map_assigned_to_which_group">
+    <cd:Integer>
+      <cd:Description>Index of the group to which the measurements are assigned</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="mie_map_assigned_to_which_subgroup">
+    <cd:Integer>
+      <cd:Description>Index of the subgroup to which the measurements are assigned</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="spare2">
+    <cd:Integer>
+      <cd:BitSize>24</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+    <cd:Hidden/>
+  </cd:Field>
+  <cd:Field name="rayleigh_map_of_l1b_meas_used">
+    <cd:Array>
+      <cd:Description>Map of Rayleigh Measurements used by the L2B accumulations</cd:Description>
+      <cd:Dimension>24</cd:Dimension>
+      <cd:Record>
+        <cd:Field name="which_l2b_wind_id">
+          <cd:Integer>
+            <cd:Description>reference to the L2B wind result to which this L1B range bin contributed. It will be set to 0 if not used.</cd:Description>
+            <cd:BitSize>32</cd:BitSize>
+            <cd:NativeType>uint32</cd:NativeType>
+          </cd:Integer>
+        </cd:Field>
+        <cd:Field name="weight">
+          <cd:Integer>
+            <cd:Description>Weight used for this L1B range bin while accumulating the signals used to produce the L2B wind result to which this L1B range bin contributed. The valid range is 0-1000</cd:Description>
+            <cd:BitSize>16</cd:BitSize>
+            <cd:NativeType>uint16</cd:NativeType>
+          </cd:Integer>
+        </cd:Field>
+      </cd:Record>
+    </cd:Array>
+  </cd:Field>
+  <cd:Field name="rayleigh_map_assigned_to_which_group">
+    <cd:Integer>
+      <cd:Description>Index of the group to which the measurements are assigned</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="rayleigh_map_assigned_to_which_subgroup">
+    <cd:Integer>
+      <cd:Description>Index of the subgroup to which the measurements are assigned</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="spare3">
+    <cd:Integer>
+      <cd:BitSize>24</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+    <cd:Hidden/>
+  </cd:Field>
+  <cd:Field name="spare">
+    <cd:Raw>
+      <cd:Description>Spare</cd:Description>
+      <cd:BitSize>64</cd:BitSize>
+    </cd:Raw>
+    <cd:Hidden/>
+  </cd:Field>
+</cd:Record>

--- a/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
@@ -89,6 +89,13 @@
           <cd:NativeType>uint8</cd:NativeType>
         </cd:Integer>
       </cd:Field>
+      <cd:Field name="input_screening_flags5">
+        <cd:Integer>
+          <cd:Description>Fifth input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
       <cd:Field name="intref_fitting_amplitude">
         <cd:Float>
           <cd:Description>Amplitude of the curve used for fitting the internal reference spectrum</cd:Description>
@@ -261,7 +268,7 @@
   <cd:Field name="spare">
     <cd:Raw>
       <cd:Description>Spare</cd:Description>
-      <cd:BitSize>168</cd:BitSize>
+      <cd:BitSize>160</cd:BitSize>
     </cd:Raw>
     <cd:Hidden/>
   </cd:Field>

--- a/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" format="binary" name="Level_2BC_Mie_Wind_PCD_ADSR_03_70" last-modified="2022-01-19">
+  <cd:Field name="wind_result_id">
+    <cd:Integer>
+      <cd:Description>unique L2B wind result identification number for this L2B file</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="start_of_obs_datetime">
+    <cd:Time timeformat="binary_envisat_datetime">
+      <cd:Description>Start date and time of Measurement</cd:Description>
+      <ct:NamedTest id="RangeSecond" path="seconds"/>
+      <ct:NamedTest id="RangeMicroSecond" path="microseconds"/>
+    </cd:Time>
+  </cd:Field>
+  <cd:Field name="mie_wind_qc">
+    <cd:Record>
+      <cd:Description>Structure in which the wind retrieval output QC parameters for the Mie channel are collected</cd:Description>
+      <cd:Field name="hlos_error_estimate">
+        <cd:Integer>
+          <cd:Description>Error estimate reported by the Mie processing algorithm, given in cm/s and rounded to the nearest integer</cd:Description>
+          <cd:Unit>cm/s</cd:Unit>
+          <cd:BitSize>16</cd:BitSize>
+          <cd:NativeType>uint16</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="reference_hlos">
+        <cd:Integer>
+          <cd:Description>Reference HLOS wind taken from the matching profile in the AUX_MET file that was used for processing (and as is used for calculating O-B statistics), given in cm/s and rounded to the nearest integer.</cd:Description>
+          <cd:Unit>cm/s</cd:Unit>
+          <cd:BitSize>16</cd:BitSize>
+          <cd:NativeType>int16</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags1">
+        <cd:Integer>
+          <cd:Description>First flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags2">
+        <cd:Integer>
+          <cd:Description>Second flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags3">
+        <cd:Integer>
+          <cd:Description>Third flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags4">
+        <cd:Integer>
+          <cd:Description>Fourth flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags1">
+        <cd:Integer>
+          <cd:Description>First input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags2">
+        <cd:Integer>
+          <cd:Description>Second input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags3">
+        <cd:Integer>
+          <cd:Description>Third input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags4">
+        <cd:Integer>
+          <cd:Description>Fourth input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="intref_fitting_amplitude">
+        <cd:Float>
+          <cd:Description>Amplitude of the curve used for fitting the internal reference spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_residual">
+        <cd:Float>
+          <cd:Description>Residual after the fit to the internal reference spectrum is performed (should also give an idea of the reliability of the fit)</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_offset">
+        <cd:Float>
+          <cd:Description>Offset of the curve used for fitting the internal reference spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_fwhm">
+        <cd:Float>
+          <cd:Description>FWHM of the curve used for fitting internal reference the spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_peakloc">
+        <cd:Float>
+          <cd:Description>Peak location result from fitting the internal reference spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_offsetsub">
+        <cd:Float>
+          <cd:Description>Offset subtraction as applied to the fit result of the internal reference spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_valflag">
+        <cd:Integer>
+          <cd:Description>Validity flag indicating the succes of fitting the internal reference spectrum.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+          <ct:NamedTest id="BooleanBinTest"/>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="intref_fitting_mie_snr">
+        <cd:Float>
+          <cd:Description>Refined SNR value derived by fitting the internal reference spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="intref_fitting_mie_sr">
+        <cd:Float>
+          <cd:Description>Refined Scattering Ratio value derived by fitting the internal reference spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_amplitude">
+        <cd:Float>
+          <cd:Description>Amplitude of the curve used for fitting the Mie spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_residual">
+        <cd:Float>
+          <cd:Description>Residual after the fit to the Mie spectrum is performed (should also give an idea of the reliability of the fit)</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_offset">
+        <cd:Float>
+          <cd:Description>Offset of the curve used for fitting the Mie spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_fwhm">
+        <cd:Float>
+          <cd:Description>FWHM of the curve used for fitting the Mie spectrum. This gives a measure of the wind variability in this rangebin</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_peakloc">
+        <cd:Float>
+          <cd:Description>Peak location result from fitting the measured atmospheric Mie spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_offsetsub">
+        <cd:Float>
+          <cd:Description>Offset subtraction as applied to the fit result of the measured atmospheric Mie spectrum.</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_valflag">
+        <cd:Integer>
+          <cd:Description>Validity flag indicating the succes of fitting the measured atmospheric Mie spectrum.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+          <ct:NamedTest id="BooleanBinTest"/>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="fitting_mie_snr">
+        <cd:Float>
+          <cd:Description>SNR of the measured atmospheric Mie spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="fitting_mie_sr">
+        <cd:Float>
+          <cd:Description>Refined Scattering ratio value derived by fitting the accumulated measured atmospheric Mie spectrum</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="extinction">
+        <cd:Float>
+          <cd:Description>Extinction</cd:Description>
+          <cd:Unit>1/m</cd:Unit>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="mie_background_high">
+        <cd:Integer>
+          <cd:Description>A value of 1 indicates that this data was taken during daylight, so possibly the background radiation level is high.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="spare">
+    <cd:Raw>
+      <cd:Description>Spare</cd:Description>
+      <cd:BitSize>160</cd:BitSize>
+    </cd:Raw>
+    <cd:Hidden/>
+  </cd:Field>
+</cd:Record>

--- a/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Mie_Wind_PCD_ADSR_03_70.xml
@@ -261,7 +261,7 @@
   <cd:Field name="spare">
     <cd:Raw>
       <cd:Description>Spare</cd:Description>
-      <cd:BitSize>160</cd:BitSize>
+      <cd:BitSize>168</cd:BitSize>
     </cd:Raw>
     <cd:Hidden/>
   </cd:Field>

--- a/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
@@ -61,6 +61,13 @@
           <cd:NativeType>uint8</cd:NativeType>
         </cd:Integer>
       </cd:Field>
+      <cd:Field name="flags5">
+        <cd:Integer>
+          <cd:Description>Fifth flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
       <cd:Field name="input_screening_flags1">
         <cd:Integer>
           <cd:Description>First input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
@@ -139,7 +146,7 @@
   <cd:Field name="spare">
     <cd:Raw>
       <cd:Description>Spare</cd:Description>
-      <cd:BitSize>168</cd:BitSize>
+      <cd:BitSize>160</cd:BitSize>
     </cd:Raw>
     <cd:Hidden/>
   </cd:Field>

--- a/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
@@ -111,6 +111,22 @@
           <cd:NativeType>uint8</cd:NativeType>
         </cd:Integer>
       </cd:Field>
+      <cd:Field name="rr_measured">
+        <cd:Float>
+          <cd:Description>Rayleigh response used as input for the atmospheric path part of the wind retrieval calculation (without additional bias corrections)</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="rr_refpulse">
+        <cd:Float>
+          <cd:Description>Rayleigh response used as input for the internal reference path part of the wind retrieval calculation (without additional bias corrections)</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
       <cd:Field name="spare">
         <cd:Raw>
           <cd:Description>Spare</cd:Description>

--- a/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" format="binary" name="Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70" last-modified="2022-01-19">
+  <cd:Field name="wind_result_id">
+    <cd:Integer>
+      <cd:Description>unique L2B wind result identification number for this L2B file</cd:Description>
+      <cd:BitSize>32</cd:BitSize>
+      <cd:NativeType>uint32</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="start_of_obs_datetime">
+    <cd:Time timeformat="binary_envisat_datetime">
+      <cd:Description>Start date and time of Measurement</cd:Description>
+      <ct:NamedTest id="RangeSecond" path="seconds"/>
+      <ct:NamedTest id="RangeMicroSecond" path="microseconds"/>
+    </cd:Time>
+  </cd:Field>
+  <cd:Field name="rayleigh_wind_qc">
+    <cd:Record>
+      <cd:Description>Structure in which the wind retrieval output QC parameters for the Rayleigh channel are collected</cd:Description>
+      <cd:Field name="hlos_error_estimate">
+        <cd:Integer>
+          <cd:Description>Error estimate reported by the Rayleigh processing algorithm, given in cm/s and rounded to the nearest integer</cd:Description>
+          <cd:Unit>cm/s</cd:Unit>
+          <cd:BitSize>16</cd:BitSize>
+          <cd:NativeType>uint16</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="reference_hlos">
+        <cd:Integer>
+          <cd:Description>Reference HLOS wind taken from the matching profile in the AUX_MET file that was used for processing (and as is used for calculating O-B statistics), given in cm/s and rounded to the nearest integer.</cd:Description>
+          <cd:Unit>cm/s</cd:Unit>
+          <cd:BitSize>16</cd:BitSize>
+          <cd:NativeType>int16</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags1">
+        <cd:Integer>
+          <cd:Description>First flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags2">
+        <cd:Integer>
+          <cd:Description>Second flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags3">
+        <cd:Integer>
+          <cd:Description>Third flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="flags4">
+        <cd:Integer>
+          <cd:Description>Fourth flag describing Mie processing results for the current wind result.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags1">
+        <cd:Integer>
+          <cd:Description>First input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags2">
+        <cd:Integer>
+          <cd:Description>Second input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags3">
+        <cd:Integer>
+          <cd:Description>Third input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="input_screening_flags4">
+        <cd:Integer>
+          <cd:Description>Fourth input screening flag describing in detail which condition caused this current wind result to be invalid</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="scattering_ratio">
+        <cd:Float>
+          <cd:Description>Scattering Ratio used to estimate the Mie signal used in Mie decontamination for this wind result</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="scattering_ratio_method">
+        <cd:Integer>
+          <cd:Description>Scattering Ratio Method used to determine the Scattering Ratio rho for this wind result</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="rayleigh_background_high">
+        <cd:Integer>
+          <cd:Description>A value of 1 indicates that this data was taken during daylight, so possibly the background radiation level is high.</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="spare">
+    <cd:Raw>
+      <cd:Description>Spare</cd:Description>
+      <cd:BitSize>160</cd:BitSize>
+    </cd:Raw>
+    <cd:Hidden/>
+  </cd:Field>
+</cd:Record>

--- a/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
+++ b/types/Level_2BC_Rayleigh_Wind_PCD_ADSR_03_70.xml
@@ -139,7 +139,7 @@
   <cd:Field name="spare">
     <cd:Raw>
       <cd:Description>Spare</cd:Description>
-      <cd:BitSize>160</cd:BitSize>
+      <cd:BitSize>168</cd:BitSize>
     </cd:Raw>
     <cd:Hidden/>
   </cd:Field>

--- a/types/Level_2B_Meas_PCD_ADSR_03_70.xml
+++ b/types/Level_2B_Meas_PCD_ADSR_03_70.xml
@@ -309,6 +309,13 @@
                 <cd:NativeType>uint8</cd:NativeType>
               </cd:Integer>
             </cd:Field>
+            <cd:Field name="applied_classification_method">
+              <cd:Integer>
+                <cd:Description>Method applied to derive the classification decision for this rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
             <cd:Field name="spare">
               <cd:Raw>
                 <cd:Description>Spare</cd:Description>
@@ -375,6 +382,13 @@
             <cd:Field name="applied_mie_snr_method">
               <cd:Integer>
                 <cd:Description>Method applied to deduce the Mie SNR that was copied over from the matching Mie rangebin to this Rayleigh rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="applied_classification_method">
+              <cd:Integer>
+                <cd:Description>Method applied to derive the classification decision for this rangebin</cd:Description>
                 <cd:BitSize>8</cd:BitSize>
                 <cd:NativeType>uint8</cd:NativeType>
               </cd:Integer>

--- a/types/Level_2B_Meas_PCD_ADSR_03_70.xml
+++ b/types/Level_2B_Meas_PCD_ADSR_03_70.xml
@@ -231,7 +231,14 @@
                     <cd:NativeType>uint8</cd:NativeType>
                   </cd:Integer>
                 </cd:Field>
-                <cd:Field name="bin_qc_flags">
+                <cd:Field name="bin_qc_flags1">
+                  <cd:Integer>
+                    <cd:Description>Flags describing problems which prevent using this Rayleigh measurement bin. Bit 1: reserved, Bit 2: reserved, ..., Bit 8: reserved</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+                <cd:Field name="bin_qc_flags2">
                   <cd:Integer>
                     <cd:Description>Flags describing problems which prevent using this Rayleigh measurement bin. Bit 1: reserved, Bit 2: reserved, ..., Bit 8: reserved</cd:Description>
                     <cd:BitSize>8</cd:BitSize>
@@ -406,7 +413,7 @@
       <cd:Field name="spare">
         <cd:Raw>
           <cd:Description>Spare</cd:Description>
-          <cd:BitSize>208</cd:BitSize>
+          <cd:BitSize>16</cd:BitSize>
         </cd:Raw>
         <cd:Hidden/>
       </cd:Field>

--- a/types/Level_2B_Meas_PCD_ADSR_03_70.xml
+++ b/types/Level_2B_Meas_PCD_ADSR_03_70.xml
@@ -1,0 +1,497 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" format="binary" name="Level_2B_Meas_PCD_ADSR_03_70" last-modified="2022-01-19">
+  <cd:Field name="start_of_obs_datetime">
+    <cd:Time timeformat="binary_envisat_datetime">
+      <cd:Description>Start date and time of Measurement</cd:Description>
+      <ct:NamedTest id="RangeSecond" path="seconds"/>
+      <ct:NamedTest id="RangeMicroSecond" path="microseconds"/>
+    </cd:Time>
+  </cd:Field>
+  <cd:Field name="l1b_brc_number">
+    <cd:Integer>
+      <cd:Description>The index of the original L1B BRC from which this L2B measurement was taken.</cd:Description>
+      <cd:BitSize>16</cd:BitSize>
+      <cd:NativeType>uint16</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="l1b_meas_number">
+    <cd:Integer>
+      <cd:Description>The index of the measurement within the above mentioned original L1B BRC from which this L2B measurement was taken.</cd:Description>
+      <cd:BitSize>16</cd:BitSize>
+      <cd:NativeType>uint16</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="l1b_num_meas_per_brc">
+    <cd:Integer>
+      <cd:Description>The number of measurements present in the original L1B BRC from which this L2B measurement was taken.</cd:Description>
+      <cd:BitSize>8</cd:BitSize>
+      <cd:NativeType>uint8</cd:NativeType>
+    </cd:Integer>
+  </cd:Field>
+  <cd:Field name="l2b_amd_collocation">
+    <cd:Record>
+      <cd:Description>Structure describing which AMD profile was used, and what the Match Up results are</cd:Description>
+      <cd:Field name="matching_amd_profile">
+        <cd:Integer>
+          <cd:Description>AMD profile number that was found to match with the current measurement</cd:Description>
+          <cd:BitSize>16</cd:BitSize>
+          <cd:NativeType>uint16</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="matchup_qc">
+        <cd:Integer>
+          <cd:Description>code that specifies whether matchup was succesull or not, and if not it gives a reason why it failed</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+          <cd:NativeType>uint8</cd:NativeType>
+        </cd:Integer>
+      </cd:Field>
+      <cd:Field name="distance">
+        <cd:Float>
+          <cd:Description>actual distance between this measurement and the selected AuxMet profile</cd:Description>
+          <cd:Unit>km</cd:Unit>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="time_difference">
+        <cd:Float>
+          <cd:Description>actual time difference between this measurement and the selected AuxMet profile</cd:Description>
+          <cd:BitSize>64</cd:BitSize>
+          <cd:NativeType>double</cd:NativeType>
+          <ct:NamedTest id="FloatIsFinite"/>
+        </cd:Float>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>8</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="l1b_input_screening">
+    <cd:Record>
+      <cd:Description>Structure describing any problems found during reading of the L1B datafile</cd:Description>
+      <cd:Field name="l1b_obs_scr">
+        <cd:Record>
+          <cd:Description>A structure that stores L1B BRC Obs level screening results on measurement level. This is needed because a L2B group no longer corresponds by definition to a single L1B BRC</cd:Description>
+          <cd:Field name="obs_screening">
+            <cd:Integer>
+              <cd:Description>a field that stores a code indicating whether the L1B Observation level screening was passed for the BRC to which this measurement belongs.</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="obs_screening_flags1">
+            <cd:Integer>
+              <cd:Description>reserved</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="obs_screening_flags2">
+            <cd:Integer>
+              <cd:Description>reserved</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="obs_screening_flags3">
+            <cd:Integer>
+              <cd:Description>reserved</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="obs_screening_flags4">
+            <cd:Integer>
+              <cd:Description>reserved</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="obs_screening_flags5">
+            <cd:Integer>
+              <cd:Description>reserved</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="mie_meas">
+        <cd:Record>
+          <cd:Description>structure describing the problems found for this Mie measurement</cd:Description>
+          <cd:Field name="meas_qc">
+            <cd:Integer>
+              <cd:Description>A code describing a problem which prevents using this Mie measurement</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags1">
+            <cd:Integer>
+              <cd:Description>Flags describing problems which prevent using this Mie Measurement. Bit 1: threshold check on num Mie invalid refpulses failed, Bit 2: threshold check on Mie avg. laser freq. offset failed, Bit 3: threshold check on Mie avg. UV energy failed, Bit 4: threshold check on Mie laser freq. offset stdev failed, Bit 5: threshold check on Mie UV energy stdev failed, Bit 6: threshold check on Mie velocity of attitude uncertainty error failed, Bit 7: threshold check on Mie mean emit freq. failed, Bit 8: threshold check on Mie emit freq. stdev failed</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags2">
+            <cd:Integer>
+              <cd:Description>Flags describing problems which prevent using this Mie Measurement. Bit 1: reserved (always set to 0), Bit 2: Moon Blinding flag was set in L1B product, Bit 3: reserved (always set to 0), ..., Bit 8: reserved (always set to 0)</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags3">
+            <cd:Integer>
+              <cd:Description>Flags describing problems which prevent using this Mie Measurement. Bit 1: reserved (always set to 0), Bit 2: reserved (always set to 0), ..., Bit 8: reserved (always set to 0).</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="bin_screening">
+            <cd:Array>
+              <cd:Dimension>24</cd:Dimension>
+              <cd:Record>
+                <cd:Field name="bin_qc">
+                  <cd:Integer>
+                    <cd:Description>A code describing a problem which prevents using this Mie measurement bin</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+                <cd:Field name="bin_qc_flags1">
+                  <cd:Integer>
+                    <cd:Description>Flags describing problems which prevent using this Mie measurement bin. Bit 1: reserved, Bit 2: reserved, ..., Bit 8: reserved</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+                <cd:Field name="bin_qc_flags2">
+                  <cd:Integer>
+                    <cd:Description>Flags describing problems which prevent using this Mie measurement bin. Bit 1: reserved, Bit 2: reserved, ..., Bit 8: reserved</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+              </cd:Record>
+            </cd:Array>
+          </cd:Field>
+          <cd:Field name="spare">
+            <cd:Raw>
+              <cd:Description>Spare</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+            </cd:Raw>
+            <cd:Hidden/>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="rayleigh_meas">
+        <cd:Record>
+          <cd:Description>structure describing the problems found for this Rayleigh measurement</cd:Description>
+          <cd:Field name="meas_qc">
+            <cd:Integer>
+              <cd:Description>A code describing a problem which prevents using this Rayleigh measurement</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags1">
+            <cd:Integer>
+              <cd:Description>Flags describing problems which prevent using this Rayleigh Measurement. Bit 1: threshold check on num Rayleigh invalid refpulses failed, Bit 2: threshold check on Rayleigh avg. laser freq. offset failed, Bit 3: threshold check on Rayleigh avg. UV energy failed, Bit 4: threshold check on Rayleigh laser freq. offset stdev failed, Bit 5: threshold check on Rayleigh UV energy stdev failed, Bit 6: threshold check on Rayleigh velocity of attitude uncertainty error failed, Bit 7: threshold check on Rayleigh mean emit freq. failed, Bit 8: threshold check on Rayleigh emit freq. stdev failed</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags2">
+            <cd:Integer>
+              <cd:Description>Bit 1: threshold check on Mie emit freq. stdev failed and was propagated on to the Rayleigh channel, Bit 2: Moon Blinding flag was set in L1B product, Bit 3: reserved (always set to 0), ..., Bit 8: reserved (always set to 0)</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="meas_qc_flags3">
+            <cd:Integer>
+              <cd:Description>Flags describing problems which prevent using this Rayleigh Measurement. Bit 1: reserved (always set to 0), Bit 2: reserved (always set to 0), ..., Bit 8: reserved (always set to 0).</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+              <cd:NativeType>uint8</cd:NativeType>
+            </cd:Integer>
+          </cd:Field>
+          <cd:Field name="bin_screening">
+            <cd:Array>
+              <cd:Dimension>24</cd:Dimension>
+              <cd:Record>
+                <cd:Field name="bin_qc">
+                  <cd:Integer>
+                    <cd:Description>A code describing a problem which prevents using this Rayleigh measurement bin</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+                <cd:Field name="bin_qc_flags">
+                  <cd:Integer>
+                    <cd:Description>Flags describing problems which prevent using this Rayleigh measurement bin. Bit 1: reserved, Bit 2: reserved, ..., Bit 8: reserved</cd:Description>
+                    <cd:BitSize>8</cd:BitSize>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Field>
+              </cd:Record>
+            </cd:Array>
+          </cd:Field>
+          <cd:Field name="spare">
+            <cd:Raw>
+              <cd:Description>Spare</cd:Description>
+              <cd:BitSize>8</cd:BitSize>
+            </cd:Raw>
+            <cd:Hidden/>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>160</cd:BitSize>
+        </cd:Raw>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="l2b_mie_classification_qc">
+    <cd:Record>
+      <cd:Field name="l2b_mie_meas_bin_classification">
+        <cd:Array>
+          <cd:Dimension>24</cd:Dimension>
+          <cd:Record>
+            <cd:Description>Structure describing QC parameters resulting from the Mie Classification algorithm</cd:Description>
+            <cd:Field name="l2b_mie_meas_bin_class_flags1">
+              <cd:Integer>
+                <cd:Description>First byte of 8 flags describing classification properties for the current Mie measurement rangebin.</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="l2b_mie_meas_bin_class_flags2">
+              <cd:Integer>
+                <cd:Description>First byte of 8 flags describing classification properties for the current Mie measurement rangebin.</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="l2b_reliability">
+              <cd:Float>
+                <cd:Description>A measure for the reliability of the classification result for this rangebin.</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="backscatter_ratio">
+              <cd:Float>
+                <cd:Description>Backscatter ratio deduced for this rangebin</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="applied_scatratio_method">
+              <cd:Integer>
+                <cd:Description>Method applied to deduce Backscatter ratio for this rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="SNR">
+              <cd:Float>
+                <cd:Description>Signal-to-Noise ratio deduced for this rangebin</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="applied_snr_method">
+              <cd:Integer>
+                <cd:Description>Method applied to deduce SNR for this rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="spare">
+              <cd:Raw>
+                <cd:Description>Spare</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+              </cd:Raw>
+              <cd:Hidden/>
+            </cd:Field>
+          </cd:Record>
+        </cd:Array>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>24</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="l2b_rayleigh_classification_qc">
+    <cd:Record>
+      <cd:Field name="l2b_rayleigh_meas_bin_classification">
+        <cd:Array>
+          <cd:Dimension>24</cd:Dimension>
+          <cd:Record>
+            <cd:Description>Structure describing QC parameters resulting from the Rayleigh Classification algorithm</cd:Description>
+            <cd:Field name="l2b_rayleigh_meas_bin_class_flags1">
+              <cd:Integer>
+                <cd:Description>First byte of 8 flags describing classification properties for the current Rayleigh measurement rangebin.</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="l2b_rayleigh_meas_bin_class_flags2">
+              <cd:Integer>
+                <cd:Description>First byte of 8 flags describing classification properties for the current Rayleigh measurement rangebin.</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="l2b_reliability">
+              <cd:Float>
+                <cd:Description>A measure for the reliability of the classification result for this rangebin.</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="backscatter_ratio">
+              <cd:Float>
+                <cd:Description>Backscatter ratio deduced for this rangebin</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="applied_scatratio_method">
+              <cd:Integer>
+                <cd:Description>Method applied to deduce Backscatter ratio for this rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="selected_mie_snr">
+              <cd:Float>
+                <cd:Description>Mie Signal-to-Noise ratio that was copied over from the matching Mie rangebin to this Rayleigh rangebin</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="applied_mie_snr_method">
+              <cd:Integer>
+                <cd:Description>Method applied to deduce the Mie SNR that was copied over from the matching Mie rangebin to this Rayleigh rangebin</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="spare">
+              <cd:Raw>
+                <cd:Description>Spare</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+              </cd:Raw>
+              <cd:Hidden/>
+            </cd:Field>
+          </cd:Record>
+        </cd:Array>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>16</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="opt_prop_result">
+    <cd:Record>
+      <cd:Field name="opt_prop_meas_result">
+        <cd:Array>
+          <cd:Dimension>24</cd:Dimension>
+          <cd:Record>
+            <cd:Description>Structure describing the results of the iterative Optical properties algorithm for this measurement</cd:Description>
+            <cd:Field name="extinction_iterative">
+              <cd:Float>
+                <cd:Description>Aerosol extinction as determined by the iterative Optical Properties Algorithm</cd:Description>
+                <cd:Unit>1/m</cd:Unit>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="scattering_ratio_iterative">
+              <cd:Float>
+                <cd:Description>Scattering ratio as determined by the iterative Optical Properties Algorithm</cd:Description>
+                <cd:BitSize>64</cd:BitSize>
+                <cd:NativeType>double</cd:NativeType>
+                <ct:NamedTest id="FloatIsFinite"/>
+              </cd:Float>
+            </cd:Field>
+            <cd:Field name="xtalk_detected">
+              <cd:Integer>
+                <cd:Description>Switch to indicate if cross talk was detected or not by the iterative Optical Properties Algorithm</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="layer_top">
+              <cd:Integer>
+                <cd:Description>Top of the cloud layer detected by the iterative Optical Properties Algorithm</cd:Description>
+                <cd:Unit>m</cd:Unit>
+                <cd:BitSize>32</cd:BitSize>
+                <cd:NativeType>int32</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="layer_bottom">
+              <cd:Integer>
+                <cd:Description>Bottom of the cloud layer detected by the iterative Optical Properties Algorithm</cd:Description>
+                <cd:Unit>m</cd:Unit>
+                <cd:BitSize>32</cd:BitSize>
+                <cd:NativeType>int32</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="layer_method">
+              <cd:Integer>
+                <cd:Description>Method used by the iterative Optical Properties Algorithm to determine the cloud layer. -1 = Layer Method Undefined; 1 = Layer Method partial bin; 2 = Layer Method filled bins</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+                <cd:NativeType>int8</cd:NativeType>
+              </cd:Integer>
+            </cd:Field>
+            <cd:Field name="spare">
+              <cd:Raw>
+                <cd:Description>Spare</cd:Description>
+                <cd:BitSize>8</cd:BitSize>
+              </cd:Raw>
+              <cd:Hidden/>
+            </cd:Field>
+          </cd:Record>
+        </cd:Array>
+      </cd:Field>
+      <cd:Field name="spare">
+        <cd:Raw>
+          <cd:Description>Spare</cd:Description>
+          <cd:BitSize>40</cd:BitSize>
+        </cd:Raw>
+        <cd:Hidden/>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="spare">
+    <cd:Raw>
+      <cd:Description>Spare</cd:Description>
+      <cd:BitSize>160</cd:BitSize>
+    </cd:Raw>
+    <cd:Hidden/>
+  </cd:Field>
+</cd:Record>

--- a/types/Level_2B_Meas_PCD_ADSR_03_70.xml
+++ b/types/Level_2B_Meas_PCD_ADSR_03_70.xml
@@ -406,7 +406,7 @@
       <cd:Field name="spare">
         <cd:Raw>
           <cd:Description>Spare</cd:Description>
-          <cd:BitSize>16</cd:BitSize>
+          <cd:BitSize>208</cd:BitSize>
         </cd:Raw>
         <cd:Hidden/>
       </cd:Field>

--- a/types/Level_2B_Meas_PCD_ADSR_03_70.xml
+++ b/types/Level_2B_Meas_PCD_ADSR_03_70.xml
@@ -279,14 +279,6 @@
                 <cd:NativeType>uint8</cd:NativeType>
               </cd:Integer>
             </cd:Field>
-            <cd:Field name="l2b_reliability">
-              <cd:Float>
-                <cd:Description>A measure for the reliability of the classification result for this rangebin.</cd:Description>
-                <cd:BitSize>64</cd:BitSize>
-                <cd:NativeType>double</cd:NativeType>
-                <ct:NamedTest id="FloatIsFinite"/>
-              </cd:Float>
-            </cd:Field>
             <cd:Field name="backscatter_ratio">
               <cd:Float>
                 <cd:Description>Backscatter ratio deduced for this rangebin</cd:Description>
@@ -356,14 +348,6 @@
                 <cd:BitSize>8</cd:BitSize>
                 <cd:NativeType>uint8</cd:NativeType>
               </cd:Integer>
-            </cd:Field>
-            <cd:Field name="l2b_reliability">
-              <cd:Float>
-                <cd:Description>A measure for the reliability of the classification result for this rangebin.</cd:Description>
-                <cd:BitSize>64</cd:BitSize>
-                <cd:NativeType>double</cd:NativeType>
-                <ct:NamedTest id="FloatIsFinite"/>
-              </cd:Float>
             </cd:Field>
             <cd:Field name="backscatter_ratio">
               <cd:Float>

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -2546,12 +2546,37 @@
             <cd:Record namexml="L1B_Rayleigh_Meas_Screening_Params">
               <cd:Description>Parameters used for screening the L1B Rayleigh Measurements from the L1B input file</cd:Description>
               <cd:Field name="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Check">
-                <cd:Type namexml="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Check">
-                  <cd:Integer format="ascii">
-                    <cd:Description>Check definition to verify the value of num_of_Rayleigh_invalid_reference_pulses</cd:Description>
-                    <cd:NativeType>int32</cd:NativeType>
-                  </cd:Integer>
-                </cd:Type>
+                <cd:Record namexml="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Check">
+                  <cd:Field name="Flag_Measurements_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, measurements failing the current check are flagged invalid and not considered as Invalid input to the classification algorithm.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Flag_Wind_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, then the current wind result is flagged invalid in case any of the measurements used in the accumulation that is used to calculate this wind fails the current check.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Max_Threshold">
+                    <cd:Integer format="ascii">
+                      <cd:NativeType>uint32</cd:NativeType>
+                    </cd:Integer>
+                  </cd:Field>
+                </cd:Record>
               </cd:Field>
               <cd:Field name="L1B_Avg_Laser_Freq_Offset_Check">
                 <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Check">

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -2809,19 +2809,33 @@
           <cd:Field name="L1B_Shared_Meas_Screening_Params">
             <cd:Record namexml="L1B_Shared_Meas_Screening_Params">
               <cd:Description>Shared parameters for both channels used for screening the L1B Rayleigh Measurements from the L1B input file.</cd:Description>
-              <cd:Field name="Apply_Moonblinding_Check">
-                <cd:Type namexml="Apply_Moonblinding_Check">
-                  <cd:Integer format="ascii">
-                    <cd:Description>Switch that controls if the moon blinding flag provided by the L1B product is used for flagging measurements invalid.</cd:Description>
-                    <cd:NativeType>uint8</cd:NativeType>
-                    <cd:Mapping string="FALSE" value="0"/>
-                    <cd:Mapping string="False" value="0"/>
-                    <cd:Mapping string="false" value="0"/>
-                    <cd:Mapping string="TRUE" value="1"/>
-                    <cd:Mapping string="True" value="1"/>
-                    <cd:Mapping string="true" value="1"/>
-                  </cd:Integer>
-                </cd:Type>
+              <cd:Field name="Moonblinding_Check">
+                <cd:Record namexml="Moonblinding_Check">
+                  <cd:Field name="Flag_Measurements_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, measurements failing the current check are flagged invalid and not considered as Invalid input to the classification algorithm.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Flag_Wind_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, then the current wind result is flagged invalid in case any of the measurements used in the accumulation that is used to calculate this wind fails the current check.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                </cd:Record>
               </cd:Field>
             </cd:Record>
           </cd:Field>

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -2627,16 +2627,52 @@
                 </cd:Record>
               </cd:Field>
               <cd:Field name="L1B_Avg_UV_Energy_Check">
-                <cd:Type namexml="L1B_Avg_UV_Energy_Check">
-                  <cd:Attribute name="unit">
-                    <cd:FixedValue>mJ</cd:FixedValue>
-                  </cd:Attribute>
-                  <cd:Float format="ascii">
-                    <cd:Description>Check definition to verify the value for Avg_UV_Energy</cd:Description>
-                    <cd:Unit>mJ</cd:Unit>
-                    <cd:NativeType>double</cd:NativeType>
-                  </cd:Float>
-                </cd:Type>
+                <cd:Record namexml="L1B_Avg_UV_Energy_Check">
+                  <cd:Field name="Flag_Measurements_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, measurements failing the current check are flagged invalid and not considered as invalid input to the classification algorithm.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Flag_Wind_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, then the current wind result is flagged invalid in case any of the measurements used in the accumulation that is used to calculate this wind fails the current check.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Min_Threshold">
+                    <cd:Type namexml="Min_Threshold">
+                      <cd:Description>Lower threshold. If the value to be checked is below this value the check fails.</cd:Description>
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Unit>mJ</cd:Unit>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Max_Threshold">
+                    <cd:Type namexml="Max_Threshold">
+                      <cd:Description>Upper threshold. If the value to be checked is above this value the check fails.</cd:Description>
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Unit>mJ</cd:Unit>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                </cd:Record>
               </cd:Field>
               <cd:Field name="L1B_Laser_Freq_Offset_Stdev_Threshold">
                 <cd:Type namexml="L1B_Laser_Freq_Offset_Stdev_Threshold">

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -2579,14 +2579,52 @@
                 </cd:Record>
               </cd:Field>
               <cd:Field name="L1B_Avg_Laser_Freq_Offset_Check">
-                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Check">
-                  <cd:Attribute name="unit"/>
-                  <cd:Float format="ascii">
-                    <cd:Description>Check definition to verify the value for Avg_Laser_Frequency_Offset</cd:Description>
-                    <cd:Unit>GHz</cd:Unit>
-                    <cd:NativeType>double</cd:NativeType>
-                  </cd:Float>
-                </cd:Type>
+                <cd:Record namexml="L1B_Avg_Laser_Freq_Offset_Check">
+                  <cd:Field name="Flag_Measurements_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, measurements failing the current check are flagged invalid and not considered as invalid input to the classification algorithm.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Flag_Wind_Invalid">
+                    <cd:Integer format="ascii">
+                      <cd:Description>If set, then the current wind result is flagged invalid in case any of the measurements used in the accumulation that is used to calculate this wind fails the current check.</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                      <cd:Mapping string="FALSE" value="0"/>
+                      <cd:Mapping string="False" value="0"/>
+                      <cd:Mapping string="false" value="0"/>
+                      <cd:Mapping string="TRUE" value="1"/>
+                      <cd:Mapping string="True" value="1"/>
+                      <cd:Mapping string="true" value="1"/>
+                    </cd:Integer>
+                  </cd:Field>
+                  <cd:Field name="Min_Threshold">
+                    <cd:Type namexml="Min_Threshold">
+                      <cd:Description>Lower threshold. If the value to be checked is below this value the check fails.</cd:Description>
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Unit>GHz</cd:Unit>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Max_Threshold">
+                    <cd:Type namexml="Max_Threshold">
+                      <cd:Description>Upper threshold. If the value to be checked is above this value the check fails.</cd:Description>
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Unit>GHz</cd:Unit>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                </cd:Record>
               </cd:Field>
               <cd:Field name="L1B_Avg_UV_Energy_Check">
                 <cd:Type namexml="L1B_Avg_UV_Energy_Check">

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -2545,53 +2545,31 @@
           <cd:Field name="L1B_Rayleigh_Meas_Screening_Params">
             <cd:Record namexml="L1B_Rayleigh_Meas_Screening_Params">
               <cd:Description>Parameters used for screening the L1B Rayleigh Measurements from the L1B input file</cd:Description>
-              <cd:Field name="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Threshold">
-                <cd:Type namexml="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Threshold">
+              <cd:Field name="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Check">
+                <cd:Type namexml="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Check">
                   <cd:Integer format="ascii">
-                    <cd:Description>Threshold on the value of num_of_Rayleigh_invalid_reference_pulses</cd:Description>
+                    <cd:Description>Check definition to verify the value of num_of_Rayleigh_invalid_reference_pulses</cd:Description>
                     <cd:NativeType>int32</cd:NativeType>
                   </cd:Integer>
                 </cd:Type>
               </cd:Field>
-              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Min">
-                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Min">
+              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Check">
+                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Check">
                   <cd:Attribute name="unit"/>
                   <cd:Float format="ascii">
-                    <cd:Description>Minimum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
+                    <cd:Description>Check definition to verify the value for Avg_Laser_Frequency_Offset</cd:Description>
                     <cd:Unit>GHz</cd:Unit>
                     <cd:NativeType>double</cd:NativeType>
                   </cd:Float>
                 </cd:Type>
               </cd:Field>
-              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Max">
-                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Max">
-                  <cd:Attribute name="unit"/>
-                  <cd:Float format="ascii">
-                    <cd:Description>Maximum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
-                    <cd:Unit>GHz</cd:Unit>
-                    <cd:NativeType>double</cd:NativeType>
-                  </cd:Float>
-                </cd:Type>
-              </cd:Field>
-              <cd:Field name="L1B_Avg_UV_Energy_Min">
-                <cd:Type namexml="L1B_Avg_UV_Energy_Min">
+              <cd:Field name="L1B_Avg_UV_Energy_Check">
+                <cd:Type namexml="L1B_Avg_UV_Energy_Check">
                   <cd:Attribute name="unit">
                     <cd:FixedValue>mJ</cd:FixedValue>
                   </cd:Attribute>
                   <cd:Float format="ascii">
-                    <cd:Description>Minimum allowed value for Avg_UV_Energy</cd:Description>
-                    <cd:Unit>mJ</cd:Unit>
-                    <cd:NativeType>double</cd:NativeType>
-                  </cd:Float>
-                </cd:Type>
-              </cd:Field>
-              <cd:Field name="L1B_Avg_UV_Energy_Max">
-                <cd:Type namexml="L1B_Avg_UV_Energy_Max">
-                  <cd:Attribute name="unit">
-                    <cd:FixedValue>mJ</cd:FixedValue>
-                  </cd:Attribute>
-                  <cd:Float format="ascii">
-                    <cd:Description>Maximum allowed value for Avg_UV_Energy</cd:Description>
+                    <cd:Description>Check definition to verify the value for Avg_UV_Energy</cd:Description>
                     <cd:Unit>mJ</cd:Unit>
                     <cd:NativeType>double</cd:NativeType>
                   </cd:Float>

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -159,6 +159,21 @@
           </cd:Field>
         </cd:Record>
       </cd:Field>
+      <cd:Field name="Subgrouping_Params">
+        <cd:Record namexml="Subgrouping_Params">
+          <cd:Description>Parameters controlling the subgrouping scheme applied by the L2B processing.</cd:Description>
+          <cd:Field name="Subgroup_Method">
+            <cd:Text>
+              <cd:Description>Method to be used for composing subgroups of measurements, intended to increase the SNR of the signal before entering the optical properties and classification algorithm.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Num_Meas_to_Combine">
+            <cd:Integer format="ascii">
+              <cd:Description>Defines how many measurements will be combined together as a subgroup, in case the subgroup method is set to “n_meas”.</cd:Description>
+            </cd:Integer>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
       <cd:Field name="Classification_Params">
         <cd:Record namexml="Classification_Params">
           <cd:Description>Parameters for the Classification algorithm</cd:Description>

--- a/types/Level_2B_Proc_Params_03_70.xml
+++ b/types/Level_2B_Proc_Params_03_70.xml
@@ -1,0 +1,3168 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" name="Level_2B_Proc_Params_03_70" format="xml" namexml="Level_2B_Proc_Params" last-modified="2022-01-19">
+  <cd:Description>Level 2B Processing Parameters GADS DSR</cd:Description>
+  <cd:Field name="FH_Default_Fields">
+    <cd:Record namexml="FH_Default_Fields">
+      <cd:Description>Fields responsible for populating the Fixed Header</cd:Description>
+      <cd:Field name="File_Description">
+        <cd:Text namexml="File_Description">
+          <cd:Description>1-line description of the file</cd:Description>
+        </cd:Text>
+      </cd:Field>
+      <cd:Field name="Mission">
+        <cd:Text namexml="Mission">
+          <cd:Description>Aeolus</cd:Description>
+        </cd:Text>
+      </cd:Field>
+      <cd:Field name="File_Version">
+        <cd:Type namexml="File_Version">
+          <cd:Integer format="ascii">
+            <cd:Description>4 digits used to distinguish between versions of a file having the same validity period</cd:Description>
+            <cd:NativeType>int16</cd:NativeType>
+          </cd:Integer>
+        </cd:Type>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="WVM_Params">
+    <cd:Record namexml="WVM_Params">
+      <cd:Description>Processing parameters for Wind Velocity Measurement</cd:Description>
+      <cd:Field name="File_Type">
+        <cd:Text namexml="File_Type">
+          <cd:Description>File type string</cd:Description>
+        </cd:Text>
+      </cd:Field>
+      <cd:Field name="Sph_Descriptor">
+        <cd:Text namexml="Sph_Descriptor">
+          <cd:Description>ASCII string describing the product</cd:Description>
+        </cd:Text>
+      </cd:Field>
+      <cd:Field name="Rangebin_Mismatch_Tolerance">
+        <cd:Type namexml="Rangebin_Mismatch_Tolerance">
+          <cd:Attribute name="unit">
+            <cd:FixedValue>m</cd:FixedValue>
+          </cd:Attribute>
+          <cd:Float format="ascii">
+            <cd:Description>Tolerance above which Mie and Rayleigh rangebins are considered mismatched</cd:Description>
+            <cd:Unit>m</cd:Unit>
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Line_of_Sight_Wind_Flag">
+        <cd:Type namexml="Line_of_Sight_Wind_Flag">
+          <cd:Integer format="ascii">
+            <cd:Description>Flag indicating whether the horizontal or line-of-sight wind component should be reported</cd:Description>
+            <cd:NativeType>uint8</cd:NativeType>
+            <cd:Mapping string="FALSE" value="0"/>
+            <cd:Mapping string="False" value="0"/>
+            <cd:Mapping string="false" value="0"/>
+            <cd:Mapping string="TRUE" value="1"/>
+            <cd:Mapping string="True" value="1"/>
+            <cd:Mapping string="true" value="1"/>
+          </cd:Integer>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Grouping_Params_Mie">
+        <cd:Record namexml="Grouping_Params_Mie">
+          <cd:Description>Parameters controlling the Mie grouping scheme applied by the L2B processing.</cd:Description>
+          <cd:Field name="Grouping_Method">
+            <cd:Text namexml="Grouping_Method">
+              <cd:Description>Method to be used for composing groups of measurements, determining the maximum possible observation size after classification and accumulation.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Max_Vertical_Rangebin_Misalignment">
+            <cd:Type namexml="Max_Vertical_Rangebin_Misalignment">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum allowed vertical difference between 2 rangebins with the same index. If a rangebin is found that has a larger difference a new group will be started</cd:Description>
+                <cd:Unit>m</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Horizontal_Accumulation_Length">
+            <cd:Type namexml="Max_Horizontal_Accumulation_Length">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum horizontal difference between first and last measurement in a group. If a measurement at larger distance is found a new group will be started</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Allowed_Gap_Between_Measurements">
+            <cd:Type namexml="Max_Allowed_Gap_Between_Measurements">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum length of missing measurements before a group definition is closed and a new group is started</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Num_BRCs_to_Merge">
+            <cd:Type namexml="Num_BRCs_to_Merge">
+              <cd:Integer format="ascii">
+                <cd:Description>define how many BRCs will be combined together is a group, in case the grouping method is set to combine BRCs</cd:Description>
+                <cd:NativeType>uint32</cd:NativeType>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Grouping_Params_Rayleigh">
+        <cd:Record namexml="Grouping_Params_Rayleigh">
+          <cd:Description>Parameters controlling the Rayleigh grouping scheme applied by the L2B processing.</cd:Description>
+          <cd:Field name="Grouping_Method">
+            <cd:Text namexml="Grouping_Method">
+              <cd:Description>Method to be used for composing groups of measurements, determining the maximum possible observation size after classification and accumulation.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Max_Vertical_Rangebin_Misalignment">
+            <cd:Type namexml="Max_Vertical_Rangebin_Misalignment">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum allowed vertical difference between 2 rangebins with the same index. If a rangebin is found that has a larger difference a new group will be started</cd:Description>
+                <cd:Unit>m</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Horizontal_Accumulation_Length">
+            <cd:Type namexml="Max_Horizontal_Accumulation_Length">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum horizontal difference between first and last measurement in a group. If a measurement at larger distance is found a new group will be started</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Allowed_Gap_Between_Measurements">
+            <cd:Type namexml="Max_Allowed_Gap_Between_Measurements">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>maximum length of missing measurements before a group definition is closed and a new group is started</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Num_BRCs_to_Merge">
+            <cd:Type namexml="Num_BRCs_to_Merge">
+              <cd:Integer format="ascii">
+                <cd:Description>define how many BRCs will be combined together is a group, in case the grouping method is set to combine BRCs</cd:Description>
+                <cd:NativeType>uint32</cd:NativeType>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Classification_Params">
+        <cd:Record namexml="Classification_Params">
+          <cd:Description>Parameters for the Classification algorithm</cd:Description>
+          <cd:Field name="Classification_Type_Mie">
+            <cd:Text namexml="Classification_Type_Mie">
+              <cd:Description>The classification type for the Mie channel</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Classification_Type_Rayleigh">
+            <cd:Text namexml="Classification_Type_Rayleigh">
+              <cd:Description>The classification type for the Rayleigh channel</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Classification_Type_Rayleigh2">
+            <cd:Text namexml="Classification_Type_Rayleigh2">
+              <cd:Description>A fallback option for the classification type for the Rayleigh channel, to be used in case the primary method yields no result.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="List_of_Mie_BackscatterRatio_Thresholds">
+            <cd:Record namexml="List_of_Mie_BackscatterRatio_Thresholds">
+              <cd:Description>List of BackscatterRatio_threshold structures</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Mie_BackscatterRatio_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Mie_BackscatterRatio_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the backscatter ratio</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="List_of_Rayleigh_BackscatterRatio_Thresholds">
+            <cd:Record namexml="List_of_Rayleigh_BackscatterRatio_Thresholds">
+              <cd:Description>List of BackscatterRatio_threshold structures</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Rayleigh_BackscatterRatio_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Rayleigh_BackscatterRatio_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the backscatter ratio</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="List_of_Mie_Extinction_Thresholds">
+            <cd:Record namexml="List_of_Mie_Extinction_Thresholds">
+              <cd:Description>List of Extinction_threshold structures</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Mie_Extinction_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Mie_Extinction_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the extinction value</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>m-1</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:Unit>1/m</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="List_of_Rayleigh_Extinction_Thresholds">
+            <cd:Record namexml="List_of_Rayleigh_Extinction_Thresholds">
+              <cd:Description>List of Extinction_threshold structures</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Rayleigh_Extinction_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Rayleigh_Extinction_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the extinction value</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>m-1</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:Unit>1/m</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="List_of_Mie_SNR_Thresholds">
+            <cd:Record namexml="List_of_Mie_SNR_Thresholds">
+              <cd:Description>List of SNR_threshold structures to be used for classification of a Mie rangebin using a threshold on the SNR value.</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Mie_SNR_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Mie_SNR_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the extinction value</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="List_of_Rayleigh_Channel_Mie_SNR_Thresholds">
+            <cd:Record namexml="List_of_Rayleigh_Channel_Mie_SNR_Thresholds">
+              <cd:Description>List of SNR_threshold structures to be used for classification of a Rayleigh rangebin using a threshold on the corresponding Mie SNR value.</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Rayleigh_Channel_Mie_SNR_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Rayleigh_Channel_Mie_SNR_Threshold">
+                    <cd:Description>used for classification of a rangebin using a threshold on the extinction value</cd:Description>
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>Thresholds to be used for classification of a rangebin</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude">
+                      <cd:Type namexml="Altitude">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>km</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Altitude at which Threshold_Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Optical_Properties_Params">
+        <cd:Record namexml="Optical_Properties_Params">
+          <cd:Description>Parameters for the algorithms determining the optical properties of the atmosphere</cd:Description>
+          <cd:Field name="ScatRatio_Method">
+            <cd:Text namexml="ScatRatio_Method">
+              <cd:Description>The method to be used to get the scattering ratio</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ScatRatio_Method2">
+            <cd:Text namexml="ScatRatio_Method2">
+              <cd:Description>A backup method to get the scattering ratio, to be used when ScatRatio_Method gives no result, i.e. returns a missing_data indicator</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="SNR_Method">
+            <cd:Text namexml="SNR_Method">
+              <cd:Description>The method to be used to get the signal to noise ratio.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="SNR_Method2">
+            <cd:Text namexml="SNR_Method2">
+              <cd:Description>A backup method to get the signal to noise ratio, to be used when SNR_Method gives no result, i.e. returns a missing_data indicator.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="PartExt_Method">
+            <cd:Text namexml="PartExt_Method">
+              <cd:Description>the method to be used to get the particle extinction.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="MolExt_Method">
+            <cd:Text namexml="MolExt_Method">
+              <cd:Description>the method to be used to get the molecular extinction.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Minimum_Altitude_for_Assuming_Rho_1">
+            <cd:Type namexml="Minimum_Altitude_for_Assuming_Rho_1">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum Altitude at which scattering ratio (Rho) may be set to 1</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Minimum_Altitude_for_Assuming_SNR_0">
+            <cd:Type namexml="Minimum_Altitude_for_Assuming_SNR_0">
+              <cd:Attribute name="unit"/>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum Altitude at which signal to noise ratio (SNR) may be set to 0</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="k_power">
+            <cd:Type namexml="k_power">
+              <cd:Float format="ascii">
+                <cd:Description>Filter exponent used to damp oscillatory behaviour when retrieving bin extinction</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="FP_Xtalk_factor">
+            <cd:Type namexml="FP_Xtalk_factor">
+              <cd:Float format="ascii">
+                <cd:Description>Optional predefined cross-talk factor (not used when set to -1.0)</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Median_Filter_Window_Width_x">
+            <cd:Type namexml="Median_Filter_Window_Width_x">
+              <cd:Attribute name="unit">
+                <cd:Optional/>
+              </cd:Attribute>
+              <cd:Integer format="ascii">
+                <cd:Description>Window width in horizontal (x) direction used by median filter</cd:Description>
+                <cd:Unit>meas. index</cd:Unit>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Median_Filter_Window_Width_y">
+            <cd:Type namexml="Median_Filter_Window_Width_y">
+              <cd:Attribute name="unit">
+                <cd:Optional/>
+              </cd:Attribute>
+              <cd:Integer format="ascii">
+                <cd:Description>Window width in vertical (y) direction used by median filter</cd:Description>
+                <cd:Unit>range bin index</cd:Unit>
+                <cd:NativeType>uint8</cd:NativeType>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Calibration_from_AuxCal">
+            <cd:Type namexml="Calibration_from_AuxCal">
+              <cd:Integer format="ascii">
+                <cd:Description>If True: take Rayleigh Channel calibration values from the Aux. Cal. input file; if False: derive these values from the upper range bin</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Cross_Talk_from_AuxCal">
+            <cd:Type namexml="Cross_Talk_from_AuxCal">
+              <cd:Integer format="ascii">
+                <cd:Description>If True: derive cross-talk factor from the Aux.Cal input file; if False: t.b.d.</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Apply_Median_Filter">
+            <cd:Type namexml="Apply_Median_Filter">
+              <cd:Integer format="ascii">
+                <cd:Description>Apply the median filter to smooth out noise after applying the 2D feature finder</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Apply_2D_Feature_Finder">
+            <cd:Type namexml="Apply_2D_Feature_Finder">
+              <cd:Integer format="ascii">
+                <cd:Description>apply the 2D feature finder algorithm to find cloud and/or aerosol layers in each group of measurements</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="FP_On_Upper_Bin_Std_Threshold">
+            <cd:Type namexml="FP_On_Upper_Bin_Std_Threshold">
+              <cd:Float format="ascii">
+                <cd:Description>Threshold used to decide of the Rayleigh channel calibration factor as derived from the upper range bin is to be trusted or not</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="ScatRatio_round_to_1_below">
+            <cd:Type namexml="ScatRatio_round_to_1_below">
+              <cd:Float format="ascii">
+                <cd:Description>L1B Scattering ratio values below this value are rounded down to 1. This is useful to suppress the unevitable noise</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="ScatRatio_do_BiasCorrection">
+            <cd:Type namexml="ScatRatio_do_BiasCorrection">
+              <cd:Integer format="ascii">
+                <cd:Description>if True: use the SR bias correction to correct the SR values produced by the L1B algorithm</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_ScatRatio_BiasCorrections">
+            <cd:Record namexml="List_of_ScatRatio_BiasCorrections">
+              <cd:Description>List of BiasCorrection structures to be used for correcting the scattering ratio values</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="ScatRatio_BiasCorrection">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="ScatRatio_BiasCorrection">
+                    <cd:Description>used for classification of a rangebin using a threshold on the extinction value</cd:Description>
+                    <cd:Field name="Value">
+                      <cd:Type namexml="Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>value defining one of the x values for the curve defining the bias correction</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="BiasCorr">
+                      <cd:Type namexml="BiasCorr">
+                        <cd:Float format="ascii">
+                          <cd:Description>Bias correction value (y value) associated to the above point (x value)</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Error_Quantifier_Params">
+        <cd:Record namexml="Error_Quantifier_Params">
+          <cd:Description>Parameters for the algorithms determining the Error properties of the reported wind results</cd:Description>
+          <cd:Field name="ErrorQuantMethod_Mie">
+            <cd:Text namexml="ErrorQuantMethod_Mie">
+              <cd:Description>The method to be used to calculate the Error quantifier for the Mie channel</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ErrorQuantMethod_Rayleigh">
+            <cd:Text namexml="ErrorQuantMethod_Rayleigh">
+              <cd:Description>The method to be used to calculate the Error quantifier for the Rayleigh channel</cd:Description>
+            </cd:Text>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Common_Processing_Params">
+        <cd:Record namexml="Common_Processing_Params">
+          <cd:Description>Common Processing Parameters</cd:Description>
+          <cd:Field name="Mie_Scattering_Ratio_Params">
+            <cd:Record namexml="Mie_Scattering_Ratio_Params">
+              <cd:Description>Processing parameters for Mie product confidence params SNR and backscatter-ratio</cd:Description>
+              <cd:Field name="Alpha_Correction">
+                <cd:Type namexml="Alpha_Correction">
+                  <cd:Float format="ascii">
+                    <cd:Description>Correction factor for the calculation of the Mie SNR</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Summation_Index">
+                <cd:Type namexml="Summation_Index">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Summation index for calculation of SNR and backscatter ratio</cd:Description>
+                    <cd:NativeType>uint32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="SR_Cubic_A_x3">
+                <cd:Type namexml="SR_Cubic_A_x3">
+                  <cd:Float format="ascii">
+                    <cd:Description>Cubic correction factor for the calculation of the Mie Scattering Ratio</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="SR_Cubic_B_x2">
+                <cd:Type namexml="SR_Cubic_B_x2">
+                  <cd:Float format="ascii">
+                    <cd:Description>Cubic correction factor for the calculation of the Mie Scattering Ratio</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="SR_Cubic_C_x1">
+                <cd:Type namexml="SR_Cubic_C_x1">
+                  <cd:Float format="ascii">
+                    <cd:Description>Cubic correction factor for the calculation of the Mie Scattering Ratio</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="SR_Cubic_D_x0">
+                <cd:Type namexml="SR_Cubic_D_x0">
+                  <cd:Float format="ascii">
+                    <cd:Description>Cubic correction factor for the calculation of the Mie Scattering Ratio</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Mie_Core_Algorithm_Params">
+            <cd:Record namexml="Mie_Core_Algorithm_Params">
+              <cd:Description>Processing parameters for Mie Core Algorithm as applied for measurement data</cd:Description>
+              <cd:Field name="SNR_Threshold">
+                <cd:Type namexml="SNR_Threshold">
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold to switch Mie-Core processing on/off</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Start_FWHM">
+                <cd:Type namexml="Start_FWHM">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Starting value for FWHM</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Residual_Error_Threshold">
+                <cd:Type namexml="Residual_Error_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Stop threshold for quadratic sum of differences between modeled and measured ACCD counts per pixel</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Max_Iterations_Lorentz_Fit">
+                <cd:Type namexml="Max_Iterations_Lorentz_Fit">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Maximum number of iterations in Lorentz fit-loop</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="FWHM_Upper_Threshold">
+                <cd:Type namexml="FWHM_Upper_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Upper threshold for FWHM of Lorentz function for quality check</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="FWHM_Lower_Threshold">
+                <cd:Type namexml="FWHM_Lower_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Lower threshold for FWHM of Lorentz function for quality check</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Height_Upper_Threshold">
+                <cd:Type namexml="Peak_Height_Upper_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Relative (upper) threshold for peak height of Lorentz function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Height_Lower_Threshold">
+                <cd:Type namexml="Peak_Height_Lower_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Relative (lower) threshold for peak height of Lorentz function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Location_Threshold">
+                <cd:Type namexml="Peak_Location_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Peak location threshold</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Nonlinear_Optimization_Threshold">
+                <cd:Type namexml="Nonlinear_Optimization_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Stop threshold for Downhill Simplex algorithm merit function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Max_Iterations_Nonlinear_Optimization">
+                <cd:Type namexml="Max_Iterations_Nonlinear_Optimization">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Maximum number of interations of Downhill Simplex algorithm</cd:Description>
+                    <cd:NativeType>uint32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Num_Spectral_Sub_Samples">
+                <cd:Type namexml="Num_Spectral_Sub_Samples">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Number of functional evaluations of Lorentz fit function for one pixel</cd:Description>
+                    <cd:NativeType>uint32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Mie_Core_Algorithm_Params_Reference_Pulse">
+            <cd:Record namexml="Mie_Core_Algorithm_Params_Reference_Pulse">
+              <cd:Description>Processing parameters for Mie Core Algorithm as applied for internal reference pulses</cd:Description>
+              <cd:Field name="SNR_Threshold">
+                <cd:Type namexml="SNR_Threshold">
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold to switch Mie-Core processing on/off</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Start_FWHM">
+                <cd:Type namexml="Start_FWHM">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Starting value for FWHM</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Residual_Error_Threshold">
+                <cd:Type namexml="Residual_Error_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Stop threshold for quadratic sum of differences between modeled and measured ACCD counts per pixel</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Max_Iterations_Lorentz_Fit">
+                <cd:Type namexml="Max_Iterations_Lorentz_Fit">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Maximum number of iterations in Lorentz fit-loop</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="FWHM_Upper_Threshold">
+                <cd:Type namexml="FWHM_Upper_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Upper threshold for FWHM of Lorentz function for quality check</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="FWHM_Lower_Threshold">
+                <cd:Type namexml="FWHM_Lower_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Lower threshold for FWHM of Lorentz function for quality check</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Height_Upper_Threshold">
+                <cd:Type namexml="Peak_Height_Upper_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Relative (upper) threshold for peak height of Lorentz function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Height_Lower_Threshold">
+                <cd:Type namexml="Peak_Height_Lower_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Relative (lower) threshold for peak height of Lorentz function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Peak_Location_Threshold">
+                <cd:Type namexml="Peak_Location_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Peak location threshold</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Nonlinear_Optimization_Threshold">
+                <cd:Type namexml="Nonlinear_Optimization_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Stop threshold for Downhill Simplex algorithm merit function</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Max_Iterations_Nonlinear_Optimization">
+                <cd:Type namexml="Max_Iterations_Nonlinear_Optimization">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Maximum number of interations of Downhill Simplex algorithm</cd:Description>
+                    <cd:NativeType>uint32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Num_Spectral_Sub_Samples">
+                <cd:Type namexml="Num_Spectral_Sub_Samples">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>A.U.</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Number of functional evaluations of Lorentz fit function for one pixel</cd:Description>
+                    <cd:NativeType>uint32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Corrupt_Data_Detection_Params">
+            <cd:Record namexml="Corrupt_Data_Detection_Params">
+              <cd:Description>Parameters for corrupt data detection</cd:Description>
+              <cd:Field name="Max_Signal_Derivative">
+                <cd:Type namexml="Max_Signal_Derivative">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Maximum signal derivative. Maximum valid pixel intensity difference between adjacent CCD pixels</cd:Description>
+                    <cd:NativeType>uint16</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Pixel_Saturation_Threshold">
+                <cd:Type namexml="Pixel_Saturation_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Pixel saturation threshold</cd:Description>
+                    <cd:NativeType>uint16</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Mie_Algorithm_Params">
+        <cd:Record namexml="Mie_Algorithm_Params">
+          <cd:Description>Parameters used by the Mie algorithm.</cd:Description>
+          <cd:Field name="Copy_L1B_Mie_Core_Algorithm_Params">
+            <cd:Type namexml="Copy_L1B_Mie_Core_Algorithm_Params">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether L1B Mie Core Algorithm Parameters should be copied/used in the L2BP</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Copy_MieCoreAlgParams_to_IntRef">
+            <cd:Type namexml="Copy_MieCoreAlgParams_to_IntRef">
+              <cd:Integer format="ascii">
+                <cd:Description>In case Mie Core Algorithm Parameters are taken from the L1B product, copy the parameters used for measurement fitting to the parameters used for internal reference fitting</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Copy_L1B_Mie_ScatRatio_Algorithm_Params">
+            <cd:Type namexml="Copy_L1B_Mie_ScatRatio_Algorithm_Params">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether L1B Mie Scattering Ratio Parameters should be copied/used in the L2BP.</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Mie_Height_Assignment_Method">
+            <cd:Text namexml="Mie_Height_Assignment_Method">
+              <cd:Description>Switch to select Mie height assignment method.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Mie_Height_Weight_Upper">
+            <cd:Type namexml="Mie_Height_Weight_Upper">
+              <cd:Float format="ascii">
+                <cd:Description>Weight given to upper altitude of range bin (applicable when Mie Height Assignment Method = use fixed weight).</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Skip_Mie_Non_Linearity_Correction">
+            <cd:Type namexml="Skip_Mie_Non_Linearity_Correction">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether Mie Nonlinearity Correction should be skipped in the L2BP or not</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Extrapolate_Mie_Calibration_Data">
+            <cd:Type namexml="Extrapolate_Mie_Calibration_Data">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether Mie Nonlinearity Correction (calibration data) should be extrapolated in the L2BP or not</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Offset_Subtraction_Col20_Weight">
+            <cd:Type namexml="Offset_Subtraction_Col20_Weight">
+              <cd:Float format="ascii">
+                <cd:Description>Weight given to ACCD column 20 in (Mie) offset subtraction</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_SNR_Thresholds">
+            <cd:Record namexml="List_of_SNR_Thresholds">
+              <cd:Description>List of SNR threshold structures to be used for quality control of L2B Mie hlos retrievals. </cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="SNR_Threshold">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="SNR_Threshold">
+                    <cd:Field name="Threshold_Value">
+                      <cd:Type namexml="Threshold_Value">
+                        <cd:Float format="ascii">
+                          <cd:Description>Threshold to be used for quality control of L2B Mie hlos retrievals</cd:Description>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude_Low">
+                      <cd:Type namexml="Altitude_Low">
+                        <cd:Attribute name="unit"/>
+                        <cd:Float format="ascii">
+                          <cd:Description>Lowest altitude at which Threshold Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude_High">
+                      <cd:Type namexml="Altitude_High">
+                        <cd:Attribute name="unit"/>
+                        <cd:Float format="ascii">
+                          <cd:Description>Highest altitude at which Threshold Value is valid</cd:Description>
+                          <cd:Unit>km</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Altitude_Reference">
+                      <cd:Text namexml="Altitude_Reference">
+                        <cd:Description>Description of reference level for altitude.</cd:Description>
+                      </cd:Text>
+                    </cd:Field>
+                  </cd:Record>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Flag_Clear_Mie_Results_Invalid">
+            <cd:Type namexml="Flag_Clear_Mie_Results_Invalid">
+              <cd:Integer format="ascii">
+                <cd:Description>A switch to force all clear Mie winds to be flagged invalid</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_Invalid_Mie_Rangebins">
+            <cd:Record namexml="List_of_Invalid_Mie_Rangebins">
+              <cd:Description>A list indicating which Mie channel range bins cannot be trusted, for example due to the "hot-pixel" problem. The list size must be between 0 and 24. (3 range bins are assumed for the size calculation)</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Invalid_Mie_Rangebin">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Type namexml="Invalid_Mie_Rangebin">
+                    <cd:Integer format="ascii">
+                      <cd:Description>rangebin index defining that this rangebin cannot be trusted</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                    </cd:Integer>
+                  </cd:Type>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="spacecraft_los_vel_factor">
+            <cd:Type namexml="spacecraft_los_vel_factor">
+              <cd:Float format="ascii">
+                <cd:Description>multiplication factor applied to spacecraft LOS velocity correction to the HLOS wind result. Set to 0.0 to disable this correction. Set to 1.0 to enable it. Intermediate values are possible as well</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="manual_hlos_bias_correction">
+            <cd:Type namexml="manual_hlos_bias_correction">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>optional hlos bias correction for experimental use only (for expert use only, not intended for users not familiar with the details of the Aeolus Calibration files).</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Apply_M1_Telescope_Temperature_Correction">
+            <cd:Type namexml="Apply_M1_Telescope_Temperature_Correction">
+              <cd:Integer format="ascii">
+                <cd:Description>If set to true, switch on the M1 telescope temperature wind bias correction as defined by the AUX_TEL input file.</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Enforce_Fixed_IntRef_PeakPos">
+            <cd:Type namexml="Enforce_Fixed_IntRef_PeakPos">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch that can be used to enforce filling the Internal Reference Mie Peak Position with a constant value</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Fixed_IntRef_PeakPos_Value">
+            <cd:Type namexml="Fixed_IntRef_PeakPos_Value">
+              <cd:Attribute name="unit">
+                <cd:Optional/>
+                <cd:FixedValue>ACCD pixel index</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Fixed value to be used for the Internal Reference Mie Peak Position, in case we enforce it to be filled with a constant value</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Use_Fitted_Nonlinear_Correction">
+            <cd:Type namexml="Use_Fitted_Nonlinear_Correction">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch that can be used to enable use of the fitted non-linear correction as is provided in the incoming L1B product file</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Override_Fitted_Nonlinear_Correction_Int_Ref">
+            <cd:Type namexml="Override_Fitted_Nonlinear_Correction_Int_Ref">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch that can be used to enable overriding the fitted Mie-NL correction data for the internal path as is provided in the incoming L1B product file. Note that it will only be used if also the Use_Fitted_Nonlinear_Correction switch is set to True</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_Fitted_Int_Ref_Mie_NL_Corrections">
+            <cd:Record namexml="List_of_Fitted_Int_Ref_Mie_NL_Corrections">
+              <cd:Description>A list of ACCD pixel corrections against ACCS pixel index location that can be used to enable overriding the fitted Mie-NL correction data for the internal path as is provided in the incoming L1B product file.</cd:Description>
+              <cd:Attribute name="count"/>
+              <cd:Field name="Fitted_Int_Ref_Mie_NL_Correction">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Fitted_Int_Ref_Mie_NL_Correction">
+                    <cd:Description>Fitted Int Ref Mie NL Correction</cd:Description>
+                      <cd:Field name="Pixel_Position">
+                      <cd:Type namexml="Pixel_Position">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>ACCD pixel index</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Pixel position for which this Mie non-linearity correction will be applied</cd:Description>
+                          <cd:Unit>ACCD pixel index</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Correction">
+                      <cd:Type namexml="Correction">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Mie non-linearity correction to be applied</cd:Description>
+                          <cd:Unit>ACCD pixel</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Override_Fitted_Nonlinear_Correction_Atm_Path">
+            <cd:Type namexml="Override_Fitted_Nonlinear_Correction_Atm_Path">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch that can be used to enable overriding the fitted Mie-NL correction data for the atmospheric path as is provided in the incoming L1B product file. Note that it will only be used if also the Use_Fitted_Nonlinear_Correction switch is set to True</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_Fitted_Atm_Path_Mie_NL_Corrections">
+            <cd:Record namexml="List_of_Fitted_Atm_Path_Mie_NL_Corrections">
+              <cd:Description>A list of ACCD pixel corrections against ACCS pixel index location that can be used to enable overriding the fitted Mie-NL correction data for the atmospheric path as is provided in the incoming L1B product file.</cd:Description>
+              <cd:Attribute name="count"/>
+              <cd:Field name="Fitted_Atm_Path_Mie_NL_Correction">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Record namexml="Fitted_Atm_Path_Mie_NL_Correction">
+                    <cd:Description>Fitted_Atm_Path_Mie_NL_Correction</cd:Description>
+                    <cd:Field name="Pixel_Position">
+                      <cd:Type namexml="Pixel_Position">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>ACCD pixel index</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Pixel position for which this Mie non-linearity correction will be applied</cd:Description>
+                          <cd:Unit>ACCD pixel index</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                    <cd:Field name="Correction">
+                      <cd:Type namexml="Correction">
+                        <cd:Attribute name="unit">
+                          <cd:FixedValue>ACCD pixel</cd:FixedValue>
+                        </cd:Attribute>
+                        <cd:Float format="ascii">
+                          <cd:Description>Mie non-linearity correction to be applied</cd:Description>
+                          <cd:Unit>ACCD pixel</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Field>
+                  </cd:Record>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="RBC_Algorithm_Params">
+        <cd:Record namexml="RBC_Algorithm_Params">
+          <cd:Description>Parameters used by the RBC algorithm</cd:Description>
+          <cd:Field name="Rayleigh_Height_Assignment_Method">
+            <cd:Text namexml="Rayleigh_Height_Assignment_Method">
+              <cd:Description>Switch to select Rayleigh height assignment method.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Rayleigh_Height_Weight_Upper">
+            <cd:Type namexml="Rayleigh_Height_Weight_Upper">
+              <cd:Float format="ascii">
+                <cd:Description>Weight given to upper altitude of range bin (applicable when Rayleigh Height Assignment Method = use fixed weight)</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="ScatRatio_Method_for_Decontamination_Clear_Winds">
+            <cd:Text namexml="ScatRatio_Method_for_Decontamination_Clear_Winds">
+              <cd:Description>A switch to define how to do decontamination of the Rayleigh Clear winds.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ScatRatio_Method2_for_Decontamination_Clear_Winds">
+            <cd:Text namexml="ScatRatio_Method2_for_Decontamination_Clear_Winds">
+              <cd:Description>A switch to define a backup method controlling how to do decontamination of the Rayleigh Clear winds. Only used if the primary method yields a missing result.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ScatRatio_Method_for_Decontamination_Cloudy_Winds">
+            <cd:Text namexml="ScatRatio_Method_for_Decontamination_Cloudy_Winds">
+              <cd:Description>A switch to define how to do decontamination of the Rayleigh Cloudy winds.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ScatRatio_Method2_for_Decontamination_Cloudy_Winds">
+            <cd:Text namexml="ScatRatio_Method2_for_Decontamination_Cloudy_Winds">
+              <cd:Description>A switch to define a backup method controlling how to do decontamination of the Rayleigh Cloudy winds. Only used if the primary method yields a missing result.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Flag_Cloudy_Rayleigh_Results_Invalid">
+            <cd:Type namexml="Flag_Cloudy_Rayleigh_Results_Invalid">
+              <cd:Integer format="ascii">
+                <cd:Description>A switch to force all cloudy Rayleigh winds to be flagged invalid</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="List_of_Invalid_Rayleigh_Rangebins">
+            <cd:Record namexml="List_of_Invalid_Rayleigh_Rangebins">
+              <cd:Description>A list indicating which Rayleigh channel range bins cannot be trusted, for example due to the "hot-pixel" problem. The list size must be between 0 and 24. (3 range bins are assumed for the size calculation)</cd:Description>
+              <cd:Attribute name="count">
+              </cd:Attribute>
+              <cd:Field name="Invalid_Rayleigh_Rangebin">
+                <cd:Array>
+                  <cd:Dimension/>
+                  <cd:Type namexml="Invalid_Rayleigh_Rangebin">
+                    <cd:Integer format="ascii">
+                      <cd:Description>rangebin index defining that this rangebin cannot be trusted</cd:Description>
+                      <cd:NativeType>uint8</cd:NativeType>
+                    </cd:Integer>
+                  </cd:Type>
+                  <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+                </cd:Array>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="spacecraft_los_vel_factor">
+            <cd:Type namexml="spacecraft_los_vel_factor">
+              <cd:Float format="ascii">
+                <cd:Description>multiplication factor applied to spacecraft LOS velocity correction to the HLOS wind result. Set to 0.0 to disable this correction. Set to 1.0 to enable it. Intermediate values are possible as well</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="manual_hlos_bias_correction">
+            <cd:Type namexml="manual_hlos_bias_correction">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>optional hlos bias correction for experimental use only (for expert use only, not intended for users not familiar with the details of the Aeolus Calibration files).</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Apply_M1_Telescope_Temperature_Correction">
+            <cd:Type namexml="Apply_M1_Telescope_Temperature_Correction">
+              <cd:Integer format="ascii">
+                <cd:Description>If set to true, switch on the M1 telescope temperature wind bias correction as defined by the AUX_TEL input file.</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Enforce_Fixed_IntRef_RR">
+            <cd:Type namexml="Enforce_Fixed_IntRef_RR">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch that can be used to enforce filling the Internal Reference Rayleigh Response with a constant value</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Fixed_RR_IntRef_Value">
+            <cd:Type namexml="Fixed_RR_IntRef_Value">
+              <cd:Float format="ascii">
+                <cd:Description>Fixed value to be used for the Internal  Reference Rayleigh Response, in case we enforce it to be filled with a constant value</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Rayleigh_Cloudy_Wind_Response_Correction">
+            <cd:Record namexml="Rayleigh_Cloudy_Wind_Response_Correction">
+              <cd:Description>Parameters needed to calculate the Rayleigh Response correction for cloudy winds using the NWP based parameterization</cd:Description>
+              <cd:Field name="Apply_Correction">
+                <cd:Type namexml="Apply_Correction">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Switch that controls wether the response correction is applied or not.</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                    <cd:Mapping string="FALSE" value="0"/>
+                    <cd:Mapping string="False" value="0"/>
+                    <cd:Mapping string="false" value="0"/>
+                    <cd:Mapping string="TRUE" value="1"/>
+                    <cd:Mapping string="True" value="1"/>
+                    <cd:Mapping string="true" value="1"/>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="List_of_Alphas">
+                <cd:Record namexml="List_of_Alphas">
+                  <cd:Description>List of alpha values as used by the parameterization for the response correction</cd:Description>
+                  <cd:Attribute name="count"/>
+                  <cd:Field name="Alpha">
+                    <cd:Array>
+                      <cd:Dimension/>
+                      <cd:Type namexml="Alpha">
+                        <cd:Attribute name="unit"/>
+                        <cd:Float namexml="Alpha">
+                          <cd:Description>Alpha</cd:Description>
+                          <cd:Unit>MHz**-order</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Array>
+                  </cd:Field>
+                </cd:Record>
+              </cd:Field>
+
+              <cd:Field name="List_of_Betas">
+                <cd:Record namexml="List_of_Betas">
+                  <cd:Description>List of beta values as used by the parameterization for the response correction</cd:Description>
+                  <cd:Attribute name="count"/>
+                  <cd:Field name="Beta">
+                    <cd:Array>
+                      <cd:Dimension/>
+                      <cd:Type namexml="Beta">
+                        <cd:Attribute name="unit"/>
+                        <cd:Float namexml="Beta">
+                          <cd:Description>Beta</cd:Description>
+                          <cd:Unit>MHz**-order</cd:Unit>
+                          <cd:NativeType>double</cd:NativeType>
+                        </cd:Float>
+                      </cd:Type>
+                    </cd:Array>
+                  </cd:Field>
+                </cd:Record>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="LOS_min">
+            <cd:Type namexml="LOS_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum atmospheric signal LOS speed component</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="LOS_max">
+            <cd:Type namexml="LOS_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum atmospheric signal LOS speed component</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="LOS_ref_min">
+            <cd:Type namexml="LOS_ref_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum reference signal LOS speed component</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="LOS_ref_max">
+            <cd:Type namexml="LOS_ref_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum reference signal LOS speed component</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdR_min">
+            <cd:Type namexml="dLOSdR_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum gradient of LOS speed component with respect to rayleigh Response</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdR_max">
+            <cd:Type namexml="dLOSdR_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum gradient of LOS speed component with respect to rayleigh Response</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdT_min">
+            <cd:Type namexml="dLOSdT_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s/K</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum gradient of LOS speed component with respect to atmospheric temperature</cd:Description>
+                <cd:Unit>m/s/K</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdT_max">
+            <cd:Type namexml="dLOSdT_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s/K</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum gradient of LOS speed component with respect to atmospheric temperature</cd:Description>
+                <cd:Unit>m/s/K</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdP_min">
+            <cd:Type namexml="dLOSdP_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s/hPa</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum gradient of LOS speed component with respect to atmospheric pressure</cd:Description>
+                <cd:Unit>m/s/hPa</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdP_max">
+            <cd:Type namexml="dLOSdP_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s/hPa</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum gradient of LOS speed component with respect to atmospheric pressure</cd:Description>
+                <cd:Unit>m/s/hPa</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdrho_min">
+            <cd:Type namexml="dLOSdrho_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum gradient of LOS speed component with respect to atmospheric scattering ratio</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="dLOSdrho_max">
+            <cd:Type namexml="dLOSdrho_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum gradient of LOS speed component with respect to atmospheric scattering ratio</cd:Description>
+                <cd:Unit>m/s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="AMD_Matchup_Params">
+        <cd:Record namexml="AMD_Matchup_Params">
+          <cd:Description>Parameters used by the L1B-AMD matchup algorithm</cd:Description>
+          <cd:Field name="Matchup_Method">
+            <cd:Text namexml="Matchup_Method">
+              <cd:Description>Matchup method to be used for L1B-AMD matchup. 0: one-for-one between L1B BRC and AMD DSR, 1: Nearest-neighbour in space and time</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Max_Allowed_Time_Diff">
+            <cd:Type namexml="Max_Allowed_Time_Diff">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum allowed time difference in seconds between L1B BRC and AMD DSR</cd:Description>
+                <cd:Unit>s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Allowed_Distance">
+            <cd:Type namexml="Max_Allowed_Distance">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>km</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum allowed distance in kilometres between L1B BRC and AMD DSR</cd:Description>
+                <cd:Unit>km</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Max_Analysis_Time_Diff">
+            <cd:Type namexml="Max_Analysis_Time_Diff">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum Analysis time difference in seconds</cd:Description>
+                <cd:Unit>s</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="CLM_Matchup_Params">
+        <cd:Record namexml="CLM_Matchup_Params">
+          <cd:Description>Parameters used by the L1B-CLM matchup algorithm</cd:Description>
+          <cd:Field name="Matchup_Method">
+            <cd:Text namexml="Matchup_Method">
+              <cd:Description>Matchup method to be used for L1B-CLM matchup. 0: TBD, 1: Nearest-neighbour in space and time</cd:Description>
+            </cd:Text>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="ZWC_Params">
+        <cd:Record namexml="ZWC_Params">
+          <cd:Description>Parameters used to specify the L2B Zero-Wind Correction</cd:Description>
+          <cd:Field name="ZWC_Scheme_Mie">
+            <cd:Text namexml="ZWC_Scheme_Mie">
+              <cd:Description>Zero-Wind Correction scheme to be used for L2B Mie processing.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="ZWC_Scheme_Rayleigh">
+            <cd:Text namexml="ZWC_Scheme_Rayleigh">
+              <cd:Description>Zero-Wind Correction scheme to be used for L2B Rayleigh processing.</cd:Description>
+            </cd:Text>
+          </cd:Field>
+          <cd:Field name="Mie_Ground_Correction_Weighting">
+            <cd:Type namexml="Mie_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Mie ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Mie_HBE_Ground_Correction_Weighting">
+            <cd:Type namexml="Mie_HBE_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Mie HBE ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Rayleigh_Ground_Correction_Weighting">
+            <cd:Type namexml="Rayleigh_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Rayleigh ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Rayleigh_HBE_Ground_Correction_Weighting">
+            <cd:Type namexml="Rayleigh_HBE_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Rayleigh HBE ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Mie_Rayleigh_Ground_Correction_Weighting">
+            <cd:Type namexml="Mie_Rayleigh_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Mie-Rayleigh ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Mie_Rayleigh_HBE_Ground_Correction_Weighting">
+            <cd:Type namexml="Mie_Rayleigh_HBE_Ground_Correction_Weighting">
+              <cd:Float format="ascii">
+                <cd:Description>Mie-Rayleigh HBE ground correction weighting factor</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Mie_Rayleigh_Ground_Correction_Offset">
+            <cd:Type namexml="Mie_Rayleigh_Ground_Correction_Offset">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>m/s</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Unit>m/s</cd:Unit>
+                <cd:Description>Mie-Rayleigh ground correction weighting offset</cd:Description>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="RDB_Params">
+        <cd:Record namexml="RDB_Params">
+          <cd:Description>Parameters to control the Range Dependent Bias (RDB) correction</cd:Description>
+          <cd:Field name="Do_Mie_RDB_corr">
+            <cd:Type namexml="Do_Mie_RDB_corr">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether Mie Range Dependent Bias correction should be done in the L2BP</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Do_Rayleigh_RDB_corr">
+            <cd:Type namexml="Do_Rayleigh_RDB_corr">
+              <cd:Integer format="ascii">
+                <cd:Description>Switch to select whether Rayleigh Range Dependent Bias correction should be done in the L2BP</cd:Description>
+                <cd:NativeType>uint8</cd:NativeType>
+                <cd:Mapping string="FALSE" value="0"/>
+                <cd:Mapping string="False" value="0"/>
+                <cd:Mapping string="false" value="0"/>
+                <cd:Mapping string="TRUE" value="1"/>
+                <cd:Mapping string="True" value="1"/>
+                <cd:Mapping string="true" value="1"/>
+              </cd:Integer>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="Ground_Detection_Params">
+        <cd:Record namexml="Ground_Detection_Params">
+          <cd:Description>Parameters to control the additional ground flagging of winds on L2B side for both channels.</cd:Description>
+          <cd:Field name="Mie_Channel_Ground_Detection_Thresholds">
+            <cd:Record namexml="Mie_Channel_Ground_Detection_Thresholds">
+              <cd:Description>Structure holding threshold settings used for additional ground flagging of winds on top of the L1B defined ground detection results.</cd:Description>
+              <cd:Field name="Min_Height_Above_L1B_DEM">
+                <cd:Type namexml="Min_Height_Above_L1B_DEM">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above DEM as reported by the L1B processor for which winds will be flagged invalid. A negative value will disable this DEM check. A special value of -128 can be used to trigger a compatibility mode for which the maximum DEM height in the group will be used for this check, and not the local measurement level DEM value. The actual margin value will be set back to 0 if you use this. This will mimic the implementation that was present in L2BP v3.50 and before, and is mainly intended to be used to test the difference between the old and the new implementation.</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Min_Height_Above_L1B_Detected_Ground">
+                <cd:Type namexml="Min_Height_Above_L1B_Detected_Ground">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above detected ground as reported by the L1B processor for which winds will be flagged invalid. A negative value will disable this ground check.</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Min_Height_Above_AUX_MET_DEM">
+                <cd:Type namexml="Min_Height_Above_AUX_MET_DEM">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above DEM as reported by the AUX_MET file for which winds will be flagged invalid. A negative value will disable this AUX_MET DEM check.</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="Rayleigh_Channel_Ground_Detection_Thresholds">
+            <cd:Record namexml="Rayleigh_Channel_Ground_Detection_Thresholds">
+              <cd:Description>Structure holding threshold settings used for additional ground flagging of winds on top of the L1B defined ground detection results.</cd:Description>
+              <cd:Field name="Min_Height_Above_L1B_DEM">
+                <cd:Type namexml="Min_Height_Above_L1B_DEM">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above DEM as reported by the L1B processor for which winds will be flagged invalid</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Min_Height_Above_L1B_Detected_Ground">
+                <cd:Type namexml="Min_Height_Above_L1B_Detected_Ground">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above detected ground as reported by the L1B processor for which winds will be flagged invalid</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Min_Height_Above_AUX_MET_DEM">
+                <cd:Type namexml="Min_Height_Above_AUX_MET_DEM">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Extra margin above DEM as reported by the AUX_MET file for which winds will be flagged invalid</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="Screening_Params">
+    <cd:Record namexml="Screening_Params">
+      <cd:Description>Collected Screening Parameters used for testing the input files and the generated results</cd:Description>
+      <cd:Field name="L1B_Screening_Params">
+        <cd:Record namexml="L1B_Screening_Params">
+          <cd:Description>Parameters used for screening the L1B input file</cd:Description>
+          <cd:Field name="L1B_Geolocation_Screening_Params">
+            <cd:Record namexml="L1B_Geolocation_Screening_Params">
+              <cd:Field name="Latitude_Min">
+                <cd:Type namexml="Latitude_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum latitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees_north</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Latitude_Max">
+                <cd:Type namexml="Latitude_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum latitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees_north</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Longitude_Min">
+                <cd:Type namexml="Longitude_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum longitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees_east</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Longitude_Max">
+                <cd:Type namexml="Longitude_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum longitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees_east</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Altitude_Min">
+                <cd:Type namexml="Altitude_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum altitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Altitude_Max">
+                <cd:Type namexml="Altitude_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum altitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Altitude_DEM_Min">
+                <cd:Type namexml="Altitude_DEM_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum DEM altitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Altitude_DEM_Max">
+                <cd:Type namexml="Altitude_DEM_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum DEM altitude allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Geoid_Separation_Min">
+                <cd:Type namexml="Geoid_Separation_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum geoid separation allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Geoid_Separation_Max">
+                <cd:Type namexml="Geoid_Separation_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum geoid separation allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>km</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Topocentric_Elevation_Min">
+                <cd:Type namexml="Topocentric_Elevation_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum topocentric elevation allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Topocentric_Elevation_Max">
+                <cd:Type namexml="Topocentric_Elevation_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum topocentric elevation allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Topocentric_Azimuth_Min">
+                <cd:Type namexml="Topocentric_Azimuth_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum topocentric azimuth allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Topocentric_Azimuth_Max">
+                <cd:Type namexml="Topocentric_Azimuth_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum topocentric azimuth allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>degrees</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="AOCS_LOS_Velocity_Min">
+                <cd:Type namexml="AOCS_LOS_Velocity_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum AOCS LOS Velocity allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="AOCS_LOS_Velocity_Max">
+                <cd:Type namexml="AOCS_LOS_Velocity_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum AOCS LOS Velocity allowed in L1B Geolocation Data</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_Obs_Screening_Params">
+            <cd:Record namexml="L1B_Obs_Screening_Params">
+              <cd:Description>Parameters used for screening the L1B observations from the L1B input file</cd:Description>
+              <cd:Field name="L1B_Laser_Freq_Unlocked_Threshold">
+                <cd:Type namexml="L1B_Laser_Freq_Unlocked_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with laser_freq_unlocked</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Ref_Pulses_Unlocked_Threshold">
+                <cd:Type namexml="L1B_Ref_Pulses_Unlocked_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nrefpulses with laser_freq_unlocked</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_Freq_Offset_Threshold">
+                <cd:Type namexml="L1B_Laser_Freq_Offset_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of average laser freq. offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_UV_Energy_Threshold">
+                <cd:Type namexml="L1B_Laser_UV_Energy_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of average laser UV energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_Freq_Offs_Stdev_Threshold">
+                <cd:Type namexml="L1B_Laser_Freq_Offs_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Standard deviation for laser frequency offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_UV_Energy_Stdev_Threshold">
+                <cd:Type namexml="L1B_Laser_UV_Energy_Stdev_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Standard deviation for laser pulse UV energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Mean_Emit_Freq_Min">
+                <cd:Type namexml="L1B_Mie_Mean_Emit_Freq_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Mie mean emitted frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Mean_Emit_Freq_Max">
+                <cd:Type namexml="L1B_Mie_Mean_Emit_Freq_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximumallowed value for Mie mean emitted frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Emit_Freq_Stdev_Threshold">
+                <cd:Type namexml="L1B_Mie_Emit_Freq_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Mie emitted frequency standard deveation</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Mean_Emit_Freq_Min">
+                <cd:Type namexml="L1B_Rayleigh_Mean_Emit_Freq_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Rayleigh mean emitted frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Mean_Emit_Freq_Max">
+                <cd:Type namexml="L1B_Rayleigh_Mean_Emit_Freq_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximumallowed value for Rayleigh mean emitted frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Emit_Freq_Stdev_Threshold">
+                <cd:Type namexml="L1B_Rayleigh_Emit_Freq_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Rayleigh emitted frequency standard deviation</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Sat_Not_on_Target_Threshold">
+                <cd:Type namexml="L1B_Sat_Not_on_Target_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with sat_not_on_target</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Corrupt_Threshold">
+                <cd:Type namexml="L1B_Mie_Corrupt_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with corrupt Mie meas</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Corrupt_Threshold">
+                <cd:Type namexml="L1B_Rayleigh_Corrupt_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with corrupt Rayleigh meas</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Ref_Pulses_Corrupt_Threshold">
+                <cd:Type namexml="L1B_Mie_Ref_Pulses_Corrupt_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with corrupt Mie ref. Pulses</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayl_Ref_Pulses_Corrupt_Threshold">
+                <cd:Type namexml="L1B_Rayl_Ref_Pulses_Corrupt_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of nmeas with corrupt Rayleigh ref. Pulses</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Invalid_Meas_Threshold">
+                <cd:Type namexml="L1B_Mie_Invalid_Meas_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_mie_invalid_measurements</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Invalid_Ref_Pulses_Threshold">
+                <cd:Type namexml="L1B_Mie_Invalid_Ref_Pulses_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_mie_invalid_reference_pulse</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayl_Invalid_Meas_Threshold">
+                <cd:Type namexml="L1B_Rayl_Invalid_Meas_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_rayleigh_invalid_measurements</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayl_Invalid_Ref_Pulses_Threshold">
+                <cd:Type namexml="L1B_Rayl_Invalid_Ref_Pulses_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_rayleigh_invalid_reference_pulse</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_Mie_Meas_Screening_Params">
+            <cd:Record namexml="L1B_Mie_Meas_Screening_Params">
+              <cd:Description>Parameters used for screening the L1B Mie Measurements from the L1B input file</cd:Description>
+              <cd:Field name="L1B_Mie_Meas_Invalid_Ref_Pulses_Threshold">
+                <cd:Type namexml="L1B_Mie_Meas_Invalid_Ref_Pulses_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_mie_invalid_reference_pulses</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Min">
+                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Max">
+                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_UV_Energy_Min">
+                <cd:Type namexml="L1B_Avg_UV_Energy_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Avg_UV_Energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_UV_Energy_Max">
+                <cd:Type namexml="L1B_Avg_UV_Energy_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Avg_UV_Energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_Freq_Offset_Stdev_Threshold">
+                <cd:Type namexml="L1B_Laser_Freq_Offset_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value for Laser_Frequency_Offset_Std_ Dev</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_UV_Energy_Stdev_Threshold">
+                <cd:Type namexml="L1B_UV_Energy_Stdev_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value for UV_Energy_Std_Dev</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Vel_of_Att_Uncertainty_Error_Min">
+                <cd:Type namexml="L1B_Vel_of_Att_Uncertainty_Error_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Velocity_of_Attitude_Uncertainty_Error</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Vel_of_Att_Uncertainty_Error_Max">
+                <cd:Type namexml="L1B_Vel_of_Att_Uncertainty_Error_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Velocity_of_Attitude_Uncertainty_Error</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Mean_Emitted_Freq_Min">
+                <cd:Type namexml="L1B_Mie_Mean_Emitted_Freq_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Mie_Mean_Emitted_Frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Mean_Emitted_Freq_Max">
+                <cd:Type namexml="L1B_Mie_Mean_Emitted_Freq_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Mie_Mean_Emitted_Frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_Emitted_Freq_Stdev_Threshold">
+                <cd:Type namexml="L1B_Mie_Emitted_Freq_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Mie_Emitted_Frequency_Std_Dev</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Meas_Reference_Pulse_FWHM_Min">
+                <cd:Type namexml="L1B_Meas_Reference_Pulse_FWHM_Min">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel index</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for L1B PCD measurement-level parameter Reference_Pulse_FWHM</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Meas_Reference_Pulse_FWHM_Max">
+                <cd:Type namexml="L1B_Meas_Reference_Pulse_FWHM_Max">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD pixel index</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for L1B PCD measurement-level parameter Reference_Pulse_FWHM</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Scattering_Ratio_Min">
+                <cd:Type namexml="L1B_Scattering_Ratio_Min">
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Scattering_Ratio_Mie</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Scattering_Ratio_Max">
+                <cd:Type namexml="L1B_Scattering_Ratio_Max">
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Scattering_Ratio_Mie</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Mie_SNR_Threshold">
+                <cd:Type namexml="L1B_Mie_SNR_Threshold">
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Mie_Signal_to_Noise_Ratio</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Mie_Ground_Bin_Thickness_Threshold">
+                <cd:Type namexml="Mie_Ground_Bin_Thickness_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the part of the ground bin that is above the surface according to the DEM</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Max_Signal_Derivative">
+                <cd:Type namexml="Max_Signal_Derivative">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the Mie spectrum to be able to detect corrupt channels</cd:Description>
+                    <cd:NativeType>int16</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Pixel_Saturation_Threshold">
+                <cd:Type namexml="Pixel_Saturation_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the Mie spectral channels to be able to detect saturated channels</cd:Description>
+                    <cd:NativeType>int16</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Ignore_Mie_Meas_Invalid_Switch">
+                <cd:Type namexml="Ignore_Mie_Meas_Invalid_Switch">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Switch to select whether the L1B flag indicating an Invalid Mie Measurement should be ignored in the L2BP or not</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                    <cd:Mapping string="FALSE" value="0"/>
+                    <cd:Mapping string="False" value="0"/>
+                    <cd:Mapping string="false" value="0"/>
+                    <cd:Mapping string="TRUE" value="1"/>
+                    <cd:Mapping string="True" value="1"/>
+                    <cd:Mapping string="true" value="1"/>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_Rayleigh_Meas_Screening_Params">
+            <cd:Record namexml="L1B_Rayleigh_Meas_Screening_Params">
+              <cd:Description>Parameters used for screening the L1B Rayleigh Measurements from the L1B input file</cd:Description>
+              <cd:Field name="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Threshold">
+                <cd:Type namexml="L1B_Rayleigh_Meas_Invalid_Ref_Pulses_Threshold">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the value of num_of_Rayleigh_invalid_reference_pulses</cd:Description>
+                    <cd:NativeType>int32</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Min">
+                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_Laser_Freq_Offset_Max">
+                <cd:Type namexml="L1B_Avg_Laser_Freq_Offset_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Avg_Laser_Frequency_Offset</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_UV_Energy_Min">
+                <cd:Type namexml="L1B_Avg_UV_Energy_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Avg_UV_Energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Avg_UV_Energy_Max">
+                <cd:Type namexml="L1B_Avg_UV_Energy_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Avg_UV_Energy</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Laser_Freq_Offset_Stdev_Threshold">
+                <cd:Type namexml="L1B_Laser_Freq_Offset_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value for Laser_Frequency_Offset_Std_ Dev</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_UV_Energy_Stdev_Threshold">
+                <cd:Type namexml="L1B_UV_Energy_Stdev_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>mJ</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value for UV_Energy_Std_Dev</cd:Description>
+                    <cd:Unit>mJ</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Vel_of_Att_Uncertainty_Error_Min">
+                <cd:Type namexml="L1B_Vel_of_Att_Uncertainty_Error_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Velocity_of_Attitude_Uncertainty_Error</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Vel_of_Att_Uncertainty_Error_Max">
+                <cd:Type namexml="L1B_Vel_of_Att_Uncertainty_Error_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Velocity_of_Attitude_Uncertainty_Error</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Mean_Emitted_Freq_Min">
+                <cd:Type namexml="L1B_Rayleigh_Mean_Emitted_Freq_Min">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Rayleigh_Mean_Emitted_Frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Mean_Emitted_Freq_Max">
+                <cd:Type namexml="L1B_Rayleigh_Mean_Emitted_Freq_Max">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Rayleigh_Mean_Emitted_Frequency</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_Emitted_Freq_Stdev_Threshold">
+                <cd:Type namexml="L1B_Rayleigh_Emitted_Freq_Stdev_Threshold">
+                  <cd:Attribute name="unit"/>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the value of Rayleigh_Emitted_Frequency_Std_Dev</cd:Description>
+                    <cd:Unit>GHz</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_SNR_Min">
+                <cd:Type namexml="L1B_Rayleigh_SNR_Min">
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum allowed value for Rayleigh_Signal_to_Noise_Ratio_Channel_A and Rayleigh_Signal_to_Noise_Ratio_Channel_B</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="L1B_Rayleigh_SNR_Max">
+                <cd:Type namexml="L1B_Rayleigh_SNR_Max">
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum allowed value for Rayleigh_Signal_to_Noise_Ratio_Channel_A and Rayleigh_Signal_to_Noise_Ratio_Channel_B</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Rayleigh_Ground_Bin_Thickness_Threshold">
+                <cd:Type namexml="Rayleigh_Ground_Bin_Thickness_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Threshold on the part of the ground bin that is above the surface according to the DEM</cd:Description>
+                    <cd:Unit>m</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Pixel_Saturation_Threshold">
+                <cd:Type namexml="Pixel_Saturation_Threshold">
+                  <cd:Attribute name="unit">
+                    <cd:Optional/>
+                    <cd:FixedValue>ACCD counts</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Integer format="ascii">
+                    <cd:Description>Threshold on the Rayleigh channels to be able to detect saturated signals</cd:Description>
+                    <cd:NativeType>int16</cd:NativeType>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Ignore_Rayleigh_Meas_Invalid_Switch">
+                <cd:Type namexml="Ignore_Rayleigh_Meas_Invalid_Switch">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Switch to select whether the L1B flag indicating an Invalid Rayleigh Measurement should be ignored in the L2BP or not</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                    <cd:Mapping string="FALSE" value="0"/>
+                    <cd:Mapping string="False" value="0"/>
+                    <cd:Mapping string="false" value="0"/>
+                    <cd:Mapping string="TRUE" value="1"/>
+                    <cd:Mapping string="True" value="1"/>
+                    <cd:Mapping string="true" value="1"/>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_Shared_Meas_Screening_Params">
+            <cd:Record namexml="L1B_Shared_Meas_Screening_Params">
+              <cd:Description>Shared parameters for both channels used for screening the L1B Rayleigh Measurements from the L1B input file.</cd:Description>
+              <cd:Field name="Apply_Moonblinding_Check">
+                <cd:Type namexml="Apply_Moonblinding_Check">
+                  <cd:Integer format="ascii">
+                    <cd:Description>Switch that controls if the moon blinding flag provided by the L1B product is used for flagging measurements invalid.</cd:Description>
+                    <cd:NativeType>uint8</cd:NativeType>
+                    <cd:Mapping string="FALSE" value="0"/>
+                    <cd:Mapping string="False" value="0"/>
+                    <cd:Mapping string="false" value="0"/>
+                    <cd:Mapping string="TRUE" value="1"/>
+                    <cd:Mapping string="True" value="1"/>
+                    <cd:Mapping string="true" value="1"/>
+                  </cd:Integer>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_Cal_Char_Data_Screening_Params">
+            <cd:Record namexml="L1B_Cal_Char_Data_Screening_Params">
+              <cd:Field name="Sat_Char_Data_Screening_Params">
+                <cd:Record namexml="Sat_Char_Data_Screening_Params">
+                  <cd:Field name="Tripod_Obscur_Corr_Min">
+                    <cd:Type namexml="Tripod_Obscur_Corr_Min">
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum tripod obscuration correction allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Tripod_Obscur_Corr_Max">
+                    <cd:Type namexml="Tripod_Obscur_Corr_Max">
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum tripod obscuration correction allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                </cd:Record>
+              </cd:Field>
+              <cd:Field name="Mie_Resp_Calib_Data_Screening_Params">
+                <cd:Record namexml="Mie_Resp_Calib_Data_Screening_Params">
+                  <cd:Field name="Meas_Resp_Min">
+                    <cd:Type namexml="Meas_Resp_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie measurement channel response allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Resp_Max">
+                    <cd:Type namexml="Meas_Resp_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie measurement channel response allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Err_Mie_Resp_Min">
+                    <cd:Type namexml="Meas_Err_Mie_Resp_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie measurement channel response error (nonlinearity correction) allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Err_Mie_Resp_Max">
+                    <cd:Type namexml="Meas_Err_Mie_Resp_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie measurement channel response error (nonlinearity correction) allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Resp_Min">
+                    <cd:Type namexml="Ref_Pulse_Resp_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie internal reference pulse channel response allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Resp_Max">
+                    <cd:Type namexml="Ref_Pulse_Resp_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie internal reference pulse channel response allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Err_Mie_Resp_Min">
+                    <cd:Type namexml="Ref_Pulse_Err_Mie_Resp_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie internal reference pulse channel response error (nonlinearity correction) allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Err_Mie_Resp_Max">
+                    <cd:Type namexml="Ref_Pulse_Err_Mie_Resp_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie internal reference pulse channel response error (nonlinearity correction) allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Zero_Freq_Min">
+                    <cd:Type namexml="Ref_Pulse_Zero_Freq_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie internal reference pulse channel zero frequency allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Zero_Freq_Max">
+                    <cd:Type namexml="Ref_Pulse_Zero_Freq_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie internal reference pulse channel zero frequency allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Mean_Sensitivity_Min">
+                    <cd:Type namexml="Ref_Pulse_Mean_Sensitivity_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie internal reference pulse channel mean sensitivity allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Ref_Pulse_Mean_Sensitivity_Max">
+                    <cd:Type namexml="Ref_Pulse_Mean_Sensitivity_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie internal reference pulse channel mean sensitivity allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Zero_Freq_Min">
+                    <cd:Type namexml="Meas_Zero_Freq_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie measurement channel zero frequency allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Zero_Freq_Max">
+                    <cd:Type namexml="Meas_Zero_Freq_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie measurement channel zero frequency allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Mean_Sensitivity_Min">
+                    <cd:Type namexml="Meas_Mean_Sensitivity_Min">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Minimum Mie measurement channel mean sensitivity allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                  <cd:Field name="Meas_Mean_Sensitivity_Max">
+                    <cd:Type namexml="Meas_Mean_Sensitivity_Max">
+                      <cd:Attribute name="unit"/>
+                      <cd:Float format="ascii">
+                        <cd:Description>Maximum Mie measurement channel mean sensitivity allowed in L1B products</cd:Description>
+                        <cd:NativeType>double</cd:NativeType>
+                      </cd:Float>
+                    </cd:Type>
+                  </cd:Field>
+                </cd:Record>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+          <cd:Field name="L1B_GWD_ADS_Screening_Params">
+            <cd:Record namexml="L1B_GWD_ADS_Screening_Params">
+              <cd:Field name="Zero_Wind_Corr_Min">
+                <cd:Type namexml="Zero_Wind_Corr_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum zero-wind correction allowed in L1B products</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Zero_Wind_Corr_Max">
+                <cd:Type namexml="Zero_Wind_Corr_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum zero-wind correction allowed in L1B products</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Zero_Wind_Corr_Weight_Factor_Min">
+                <cd:Type namexml="Zero_Wind_Corr_Weight_Factor_Min">
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum zero-wind correction weighting factor allowed in L1B products</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Zero_Wind_Corr_Weight_Factor_Max">
+                <cd:Type namexml="Zero_Wind_Corr_Weight_Factor_Max">
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum zero-wind correction weighting factor allowed in L1B products</cd:Description>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Mie_Rayl_Correction_Offset_Min">
+                <cd:Type namexml="Mie_Rayl_Correction_Offset_Min">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Minimum Mie-Rayleigh correction offset allowed in L1B products</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+              <cd:Field name="Mie_Rayl_Correction_Offset_Max">
+                <cd:Type namexml="Mie_Rayl_Correction_Offset_Max">
+                  <cd:Attribute name="unit">
+                    <cd:FixedValue>m/s</cd:FixedValue>
+                  </cd:Attribute>
+                  <cd:Float format="ascii">
+                    <cd:Description>Maximum Mie-Rayleigh correction offset allowed in L1B products</cd:Description>
+                    <cd:Unit>m/s</cd:Unit>
+                    <cd:NativeType>double</cd:NativeType>
+                  </cd:Float>
+                </cd:Type>
+              </cd:Field>
+            </cd:Record>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="L2B_AMD_Screening_Params">
+        <cd:Record namexml="L2B_AMD_Screening_Params">
+          <cd:Description>Parameters used for screening the L2B_AMD input file</cd:Description>
+          <cd:Field name="L2B_AMD_p_min">
+            <cd:Type namexml="L2B_AMD_p_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>Pa</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum pressure allowed in a pressure profile</cd:Description>
+                <cd:Unit>Pa</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="L2B_AMD_p_max">
+            <cd:Type namexml="L2B_AMD_p_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>Pa</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum pressure allowed in a pressure profile</cd:Description>
+                <cd:Unit>Pa</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="L2B_AMD_T_min">
+            <cd:Type namexml="L2B_AMD_T_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>K</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum temperature allowed in a temperature profile</cd:Description>
+                <cd:Unit>K</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="L2B_AMD_T_max">
+            <cd:Type namexml="L2B_AMD_T_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>K</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum temperature allowed in a temperature profile</cd:Description>
+                <cd:Unit>K</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+      <cd:Field name="RBC_Screening_Params">
+        <cd:Record namexml="RBC_Screening_Params">
+          <cd:Description>Parameters used for screening the AUX RBC input file</cd:Description>
+          <cd:Field name="Fcalib_R_min">
+            <cd:Type namexml="Fcalib_R_min">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>GHz</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Minimum frequency allowed in the Fcalib array of the AUX_RBC input file.</cd:Description>
+                <cd:Unit>GHz</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+          <cd:Field name="Fcalib_R_max">
+            <cd:Type namexml="Fcalib_R_max">
+              <cd:Attribute name="unit">
+                <cd:FixedValue>GHz</cd:FixedValue>
+              </cd:Attribute>
+              <cd:Float format="ascii">
+                <cd:Description>Maximum frequency allowed in the Fcalib array of the AUX_RBC input file.</cd:Description>
+                <cd:Unit>GHz</cd:Unit>
+                <cd:NativeType>double</cd:NativeType>
+              </cd:Float>
+            </cd:Type>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="Monitoring_Params">
+    <cd:Record namexml="Monitoring_Params">
+      <cd:Description>Collected Monitoring Parameters used for testing the generated wind results</cd:Description>
+      <cd:Field name="Mie_Estimated_Error_Threshold">
+        <cd:Type namexml="Mie_Estimated_Error_Threshold">
+          <cd:Attribute name="unit">
+            <cd:FixedValue>m/s</cd:FixedValue>
+          </cd:Attribute>
+          <cd:Float format="ascii">
+            <cd:Description>Threshold applied to the estimated Mie wind error to select wind results that will be taken in to account in the O-B statistics. (set it to zero to disable this selection)</cd:Description>
+            <cd:Unit>m/s</cd:Unit>
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Rayleigh_Estimated_Error_Threshold">
+        <cd:Type namexml="Rayleigh_Estimated_Error_Threshold">
+          <cd:Attribute name="unit">
+            <cd:FixedValue>m/s</cd:FixedValue>
+          </cd:Attribute>
+          <cd:Float format="ascii">
+            <cd:Description>Threshold applied to the estimated Rayleigh wind error to select wind results that will be taken in to account in the O-B statistics. (set it to zero to disable this selection)</cd:Description>
+            <cd:Unit>m/s</cd:Unit>
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Use_OminB_to_Flag_Hot_Pixels">
+        <cd:Type namexml="Use_OminB_to_Flag_Hot_Pixels">
+          <cd:Integer format="ascii">
+            <cd:Description>Switch controlling wether O-minus-B statistical results will be used for quality control or not. If set to true, the following "Min_Bias_to_Flag_a_Hot_Pixel" parameter is used to decide how to flag the wind results.</cd:Description>
+            <cd:NativeType>uint8</cd:NativeType>
+            <cd:Mapping string="FALSE" value="0"/>
+            <cd:Mapping string="False" value="0"/>
+            <cd:Mapping string="false" value="0"/>
+            <cd:Mapping string="TRUE" value="1"/>
+            <cd:Mapping string="True" value="1"/>
+            <cd:Mapping string="true" value="1"/>
+          </cd:Integer>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Min_Bias_to_Flag_a_Hot_Pixel">
+        <cd:Type namexml="Min_Bias_to_Flag_a_Hot_Pixel">
+          <cd:Attribute name="unit">
+            <cd:FixedValue>m/s</cd:FixedValue>
+          </cd:Attribute>
+          <cd:Float format="ascii">
+            <cd:Description>Threshold used on bias to decide if the current range bin is affected by an uncorrected hot-pixel or not. If the above "Use_OminB_to_Flag_Hot_Pixels" switch is set to true, and if the average bias for the current file is above this threshold, the produced winds are flagged invalid.</cd:Description>
+            <cd:Unit>m/s</cd:Unit>
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Type>
+      </cd:Field>
+      <cd:Field name="Min_Nr_of_Winds_OminB_flagging">
+        <cd:Type namexml="Min_Nr_of_Winds_OminB_flagging">
+          <cd:Integer format="ascii">
+            <cd:Description>Threshold used to decide if we have enough statistics to be able to flag wind results based on O-minus-B bias. If the number of winds is too small, the statistics are not significant enough, and wind results will not be flagged, even if the bias is passed. Use a value of 0 to switch off this setting.</cd:Description>
+            <cd:NativeType>uint32</cd:NativeType>
+          </cd:Integer>
+        </cd:Type>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+  <cd:Field name="Blacklisting_Params">
+    <cd:Record namexml="Blacklisting_Params">
+      <cd:Description>Blacklisting Parameters used to flag winds invalid in case of know problems.</cd:Description>
+      <cd:Field name="List_of_Blacklisted_Periods">
+        <cd:Record namexml="List_of_Blacklisted_Periods">
+          <cd:Description>List of zero or more periods for which wind results should be blacklisted to indicate to users that the winds are not to be trusted and should most probably not be used in data assimilation or for scientific studies.</cd:Description>
+          <cd:Attribute name="count">
+          </cd:Attribute>
+          <cd:Field name="Blacklisted_Period">
+            <cd:Array>
+              <cd:Dimension/>
+              <cd:Record namexml="Blacklisted_Period">
+                <cd:Field name="Blacklisting_Start">
+                  <cd:Type namexml="Blacklisting_Start">
+                    <cd:Time format="ascii" timeformat="ascii_ccsds_datetime_ymd2_with_ref">
+                      <cd:Description>Start datetime of period to be blacklisted.</cd:Description>
+                      <cd:Mapping string="UTC=0000-00-00T00:00:00" value="-inf"/>
+                      <cd:Mapping string="UTC=9999-99-99T99:99:99" value="+inf"/>
+                    </cd:Time>
+                  </cd:Type>
+                </cd:Field>
+                <cd:Field name="Blacklisting_Stop">
+                  <cd:Type namexml="Blacklisting_Stop">
+                    <cd:Time format="ascii" timeformat="ascii_ccsds_datetime_ymd2_with_ref">
+                      <cd:Description>Stop datetime of period to be blacklisted.</cd:Description>
+                      <cd:Mapping string="UTC=0000-00-00T00:00:00" value="-inf"/>
+                      <cd:Mapping string="UTC=9999-99-99T99:99:99" value="+inf"/>
+                    </cd:Time>
+                  </cd:Type>
+                </cd:Field>
+                <cd:Field name="Channel">
+                  <cd:Text namexml="Channel">
+                    <cd:Description>Name of channel for which this blacklisting period should be applied. Allowed values are "Mie", "Rayleigh" or "Both"</cd:Description>
+                  </cd:Text>
+                </cd:Field>
+              </cd:Record>
+              <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+            </cd:Array>
+          </cd:Field>
+        </cd:Record>
+      </cd:Field>
+    </cd:Record>
+  </cd:Field>
+</cd:Record>

--- a/types/List_of_Orbit_Phase_Correction_Factors.xml
+++ b/types/List_of_Orbit_Phase_Correction_Factors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" name="List_of_Orbit_Phase_Correction_Factors" format="xml" namexml="List_of_Orbit_Phase_Correction_Factors" last-modified="2022-01-19">
+  <cd:Description>List of Orbit Phase Correction Factors</cd:Description>
+  <cd:Attribute name="count">
+  </cd:Attribute>
+  <cd:Field name="Orbit_Phase_Correction_Factor">
+    <cd:Array>
+      <cd:Dimension/>
+      <cd:Record namexml="Orbit_Phase_Correction_Factor">
+        <cd:Description>Orbit Phase Correction Factor</cd:Description>
+        <cd:Field name="Order">
+          <cd:Integer format="ascii">
+            <cd:NativeType>int8</cd:NativeType>
+          </cd:Integer>
+        </cd:Field>
+        <cd:Field name="Harmonic_Bias_Coefficient_Sin">
+          <cd:Float format="ascii">
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Field>
+        <cd:Field name="Harmonic_Bias_Coefficient_Cos">
+          <cd:Float format="ascii">
+            <cd:NativeType>double</cd:NativeType>
+          </cd:Float>
+        </cd:Field>
+      </cd:Record>
+      <ct:NamedTest id="ValueOfCountAttributeForParent"/>
+    </cd:Array>
+  </cd:Field>
+</cd:Record>

--- a/types/M1_Telescope_Temperature_Correction_Factors_03_70.xml
+++ b/types/M1_Telescope_Temperature_Correction_Factors_03_70.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<cd:Record xmlns:cd="http://www.stcorp.nl/coda/definition/2008/07" xmlns:ct="http://www.stcorp.nl/coda/test/2008/10" name="M1_Telescope_Temperature_Correction_Factors_03_70" format="xml" last-modified="2022-01-19">
+  <cd:Field name="HLOS_Bias_to_Temperature_Difference">
+    <cd:Float format="ascii">
+      <cd:Attribute name="unit">
+        <cd:FixedValue>m/s/C</cd:FixedValue>
+      </cd:Attribute>
+      <cd:Description>slope of the linear fit to the HLOS bias versus telescope temperature data.</cd:Description>
+      <cd:Unit>m/s/C</cd:Unit>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="HLOS_Bias_Offset">
+    <cd:Float format="ascii">
+      <cd:Attribute name="unit">
+        <cd:FixedValue>m/s</cd:FixedValue>
+      </cd:Attribute>
+      <cd:Description>offset of the linear fit to the HLOS bias versus telescope temperature data.</cd:Description>
+      <cd:Unit>C</cd:Unit>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_22_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_22 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_23_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_23 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_24_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_24 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_25_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_25 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_26_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_26 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="AHT_27_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor AHT_27 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_18_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_18 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_19_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_19 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_20_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_20 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_21_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_21 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_23_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_23 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_25_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_25 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_27_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_27 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_29_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_29 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+  <cd:Field name="TC_32_factor">
+    <cd:Float format="ascii">
+      <cd:Description>multiplicative factor used to include temperature sensor TC_32 in the temperature average.</cd:Description>
+      <cd:NativeType>double</cd:NativeType>
+    </cd:Float>
+  </cd:Field>
+</cd:Record>


### PR DESCRIPTION
initial support for 3.70.

note the last patch: I had to add some padding to make things fit. perhaps the test files are wrong, or the specification needs to be changed..?

there are also some 'invalid time value' errors left in 'codadump yaml', but those really seem to be invalid.

in the specification changelog it mentions 'L2B' changes, but I applied those to L2C as well, since I guess that's the idea.

another thing, do we want to add tests to check that (new) values are valid, e.g. an int must always be -1, 1 or 2. and how do we actually run all tests :-)