### PR TITLE
Update Level_2BC_Wind_Profile_MDSR_02_00.xml

### DIFF
--- a/types/Level_2BC_Wind_Profile_MDSR_02_00.xml
+++ b/types/Level_2BC_Wind_Profile_MDSR_02_00.xml
@@ -94,7 +94,7 @@
       <ct:NamedTest id="RangeMicroSecond" path="microseconds"/>
     </cd:Time>
   </cd:Field>
-  <cd:Field name="l2b_wind_profiles">
+  <cd:Field name="l2b_wind_profile">
     <cd:Record>
       <cd:Description>structure containing reference id numbers of wind retrieval results associated with the current profile for a given group and classification.</cd:Description>
       <cd:Field name="channel">


### PR DESCRIPTION
change l2b_wind_profiles in to l2b_wind_profile because this structure holds the definition of just a single profile, not of a set of profiles. This change also ensures the name is identical to what was written in the IODD.